### PR TITLE
Load a simple mpd

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
             "name": "dhara-player",
             "version": "0.0.1",
             "license": "Apache-2.0",
+            "dependencies": {
+                "events": "^3.3.0"
+            },
             "devDependencies": {
                 "@biomejs/biome": "^2.1.2",
                 "html-webpack-plugin": "^5.6.3",
@@ -1804,7 +1807,6 @@
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
             "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.x"

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
         "src/**/*.{ts,tsx}": [
             "biome lint"
         ]
+    },
+    "dependencies": {
+        "events": "^3.3.0"
     }
 }

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -1,5 +1,32 @@
-export default class DharaPlayerController {
+import { EventEmitter } from 'events';
+import Loader, { ResponseDataType } from '../services/loader';
+
+enum DPlayerState {
+    INITIAL = 'init',
+    FETCHING_SRC = 'fetching-src',
+    READY = 'ready',
+    ERROR = 'error',
+}
+
+export default class DharaPlayerController extends EventEmitter {
+    private _sourceUrl: URL | null = null;
+    private _state: DPlayerState = DPlayerState.INITIAL;
+    private readonly _loader: Loader = new Loader();
+
+    public async setSource(sourceUrl: URL) {
+        this._sourceUrl = sourceUrl;
+        this._state = DPlayerState.FETCHING_SRC;
+
+        const data = await this._loader.load(sourceUrl, {
+            responseDataType: ResponseDataType.TEXT
+        });
+
+        this._state = data ? DPlayerState.READY : DPlayerState.ERROR;
+    }
+
     public destroy() {
-        //
+        super.removeAllListeners();
+        this._sourceUrl = null;
+        this._state = DPlayerState.INITIAL;
     }
 }

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import Loader, { ResponseDataType } from '../services/loader';
+import Loader from '../services/loader';
 
 enum DPlayerState {
     INITIAL = 'init',
@@ -16,11 +16,7 @@ export default class DharaPlayerController extends EventEmitter {
     public async setSource(sourceUrl: URL) {
         this._sourceUrl = sourceUrl;
         this._state = DPlayerState.FETCHING_SRC;
-
-        const data = await this._loader.load(sourceUrl, {
-            responseDataType: ResponseDataType.TEXT
-        });
-
+        const data = await this._loader.load(sourceUrl);
         this._state = data ? DPlayerState.READY : DPlayerState.ERROR;
     }
 

--- a/src/dhara-player.ts
+++ b/src/dhara-player.ts
@@ -9,6 +9,10 @@ export default class DharaPlayer {
         this._controller = new DharaPlayerController();
     }
 
+    public setSource(sourceUrl: URL) {
+        this._controller.setSource(sourceUrl);
+    }
+
     public destroy() {
         this._controller.destroy();
     }

--- a/src/html/index-template.html
+++ b/src/html/index-template.html
@@ -1,10 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title><%= htmlWebpackPlugin.options.title %></title>
+    <title>
+        <%= htmlWebpackPlugin.options.title %>
+    </title>
 </head>
+
 <body>
     <div id="player-container">
         <h1>Dhara Player</h1>
@@ -12,7 +16,9 @@
 
     <script>
         const playerContainer = document.getElementById('player-container');
-        const player = new DHARA.Player(playerContainer);
+        const player = new window.DHARA.Player(playerContainer);
+        player.setSource(new URL('https://livesim2.dashif.org/vod/testpic_2s/audio.mpd'));
     </script>
 </body>
+
 </html>

--- a/src/services/loader.ts
+++ b/src/services/loader.ts
@@ -1,17 +1,10 @@
-export enum ResponseDataType {
-    TEXT = 'text',
-    ARRAY_BUFFER = 'arraybuffer',
-}
-
 export interface LoaderOptions {
-    responseDataType?: ResponseDataType;
     headers?: Record<string, string>;
 }
 
 type ResponseType = string | ArrayBuffer | null;
 
 export default class Loader {
-
     public async load(url: URL, options: LoaderOptions = {}): Promise<ResponseType> {
         let data: ResponseType = null;
 
@@ -24,12 +17,13 @@ export default class Loader {
                 throw new Error(`Status = ${response.status}, Failed to load: ${url}`);
             }
 
-            if (options.responseDataType === ResponseDataType.ARRAY_BUFFER) {
-                data = await response.arrayBuffer();
-            } else {
-                data = await response.text();
-            }
+            const contentType = response.headers.get('content-type');
 
+            if (contentType?.includes('application/dash+xml') || contentType?.includes('text')) {
+                data = await response.text();
+            } else {
+                data = await response.arrayBuffer();
+            }
         } catch (error: unknown) {
             console.error(error instanceof Error ? error.message : 'Unknown error');
             return null;

--- a/src/services/loader.ts
+++ b/src/services/loader.ts
@@ -1,0 +1,40 @@
+export enum ResponseDataType {
+    TEXT = 'text',
+    ARRAY_BUFFER = 'arraybuffer',
+}
+
+export interface LoaderOptions {
+    responseDataType?: ResponseDataType;
+    headers?: Record<string, string>;
+}
+
+type ResponseType = string | ArrayBuffer | null;
+
+export default class Loader {
+
+    public async load(url: URL, options: LoaderOptions = {}): Promise<ResponseType> {
+        let data: ResponseType = null;
+
+        try {
+            const response = await fetch(url, {
+                headers: options.headers,
+            });
+
+            if (!response.ok) {
+                throw new Error(`Status = ${response.status}, Failed to load: ${url}`);
+            }
+
+            if (options.responseDataType === ResponseDataType.ARRAY_BUFFER) {
+                data = await response.arrayBuffer();
+            } else {
+                data = await response.text();
+            }
+
+        } catch (error: unknown) {
+            console.error(error instanceof Error ? error.message : 'Unknown error');
+            return null;
+        }
+
+        return data;
+    }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,13 +4,13 @@ import HtmlWebpackPlugin from 'html-webpack-plugin';
 //import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname  = path.dirname(__filename);
+const __dirname = path.dirname(__filename);
 
 const srcDir = path.resolve(__dirname, 'src');
 const outputDir = path.resolve(__dirname, 'dist');
 
 export default (options) => {
-    const isProduction  = options.mode === 'production';
+    const isProduction = options.mode === 'production';
     const sourceMapType = isProduction ? 'hidden-source-map' : 'inline-source-map';
 
     return {
@@ -29,7 +29,7 @@ export default (options) => {
                 {
                     test: /\.ts$/,
                     use: 'ts-loader',
-                    include: [ srcDir ],
+                    include: [srcDir],
                     exclude: /node_modules/
                 }
             ]
@@ -42,6 +42,8 @@ export default (options) => {
                 title: 'Dhara Player',
                 filename: 'index.html',
                 template: path.resolve(srcDir, 'html/index-template.html'),
+                scriptLoading: 'blocking',
+                inject: 'head'
             }),
 
             // new BundleAnalyzerPlugin(),


### PR DESCRIPTION
## Purpose

This PR implements a loader service to load a simple MPD document. This is an audio only document. 

## Changes

- Added `events` package and uses event emitter class. Event emitting is not yet been used here. 
- Using `fetch` api, loads the mpd document. 
- Abstracts the fetching service in a `Loader` class. In future, we can implement various options here. Also, reloading on failure could be added here. 

## References
https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch

