### PR TITLE
Setup state machine

### DIFF
--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -2,27 +2,70 @@ import { EventEmitter } from 'events';
 import Loader from '../services/loader';
 
 enum DPlayerState {
-    INITIAL = 'init',
-    FETCHING_SRC = 'fetching-src',
-    READY = 'ready',
-    ERROR = 'error',
+    INITIAL = 'Init',
+    FETCHING_SRC = 'FetchingSrc',
+    PREPARING = 'Preparing',
+    READY = 'Ready',
+    ERROR = 'Error',
 }
 
 export default class DharaPlayerController extends EventEmitter {
-    private _sourceUrl: URL | null = null;
     private _state: DPlayerState = DPlayerState.INITIAL;
     private readonly _loader: Loader = new Loader();
 
     public async setSource(sourceUrl: URL) {
-        this._sourceUrl = sourceUrl;
-        this._state = DPlayerState.FETCHING_SRC;
-        const data = await this._loader.load(sourceUrl);
-        this._state = data ? DPlayerState.READY : DPlayerState.ERROR;
+        console.log(`[Controller] MPD URL = ${sourceUrl}`);
+        this.setState(DPlayerState.FETCHING_SRC, { sourceUrl });
     }
 
     public destroy() {
         super.removeAllListeners();
-        this._sourceUrl = null;
         this._state = DPlayerState.INITIAL;
+    }
+
+    private async setState(state: DPlayerState, data?: any) {
+        if (this._state === state) {
+            return;
+        }
+
+        this._state = state;
+        console.log(`[Controller] State = ${state}`);
+        this[`_on${state}`](data);
+    }
+
+    private _onInit() {
+        //
+    }
+
+    private async _onFetchingSrc(data?: any): Promise<void> {
+        const sourceUrl = data?.sourceUrl;
+        if (!sourceUrl) {
+            this.error = 'Invalid src url';
+            return;
+        }
+
+        const metadata = await this._loader.load(sourceUrl);
+        if (!metadata) {
+            this.error = 'Failed to load metadata';
+            return;
+        }
+
+        this.setState(DPlayerState.PREPARING, { metadata });
+    }
+
+    private _onPreparing() {
+        // Send the loaded metadata to the mpd parser
+    }
+
+    private _onReady() {
+        // Create video element and setup MSE
+    }
+
+    private _onError() {
+        // Send the error to the error handler
+    }
+
+    private set error(errMsg: string) {
+        this.setState(DPlayerState.ERROR, { error: new Error(errMsg) });
     }
 }


### PR DESCRIPTION
## Purpose

This PR sets up an initial version of state machine in the controller.

## Changes

Following states are added:

- Initial
- FetchingSrc: Load the mpd
- Preparing: Mpd data is available. Parse it and build model objects. Also setup audio/video tag and MSE. 
- Ready: Ready to stream (It could be preloading in future?). Create streamers. 
- Error: Got into an error state. 