### PR TITLE
Parse MPD and bootstrap model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "events": "^3.3.0",
+                "fast-xml-parser": "^5.2.5",
                 "loglevel": "^1.9.2"
             },
             "devDependencies": {
@@ -1883,6 +1884,24 @@
                 }
             ],
             "license": "BSD-3-Clause"
+        },
+        "node_modules/fast-xml-parser": {
+            "version": "5.2.5",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+            "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "strnum": "^2.1.0"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            }
         },
         "node_modules/fastest-levenshtein": {
             "version": "1.0.16",
@@ -3958,6 +3977,18 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/strnum": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+            "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/supports-color": {
             "version": "8.1.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     },
     "dependencies": {
         "events": "^3.3.0",
+        "fast-xml-parser": "^5.2.5",
         "loglevel": "^1.9.2"
     }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const ATTR_PREFIX = '@';

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -1,6 +1,8 @@
 import { EventEmitter } from 'events';
 import Loader from '../services/loader';
 import log from 'loglevel';
+import MpdParser from '../services/mpd-parser';
+import Mpd from '../model/mpd';
 
 log.setLevel('info');
 
@@ -56,8 +58,14 @@ export default class DharaPlayerController extends EventEmitter {
         this.setState(DPlayerState.PREPARING, { metadata });
     }
 
-    private _onPreparing() {
-        // Send the loaded metadata to the mpd parser
+    private async _onPreparing(data?: any) {
+        if (!data?.metadata) {
+            return;
+        }
+
+        const mpdJson = new MpdParser().parse(data.metadata);
+        const mpd = new Mpd(mpdJson);
+        console.log(mpd);
     }
 
     private _onReady() {

--- a/src/html/index-template.html
+++ b/src/html/index-template.html
@@ -18,6 +18,7 @@
         const playerContainer = document.getElementById('player-container');
         const player = new window.DHARA.Player(playerContainer);
         player.setSource(new URL('https://livesim2.dashif.org/vod/testpic_2s/audio.mpd'));
+        // player.setSource(new URL('https://dash.akamaized.net/dash264/TestCases/5a/nomor/1.mpd'));
     </script>
 </body>
 

--- a/src/model/base.ts
+++ b/src/model/base.ts
@@ -1,0 +1,66 @@
+import { ArrayTypes } from './data-types';
+import { ATTR_PREFIX } from '../constants';
+
+/**
+ * Base class for all Dash model objects.
+ *
+ * The base provides methods to automatically create members
+ * (simple types and the children objects) of the model classes from the JSON input.
+ */
+export default class ModelBase {
+    constructor(json: Record<string, any>,
+                types?: Record<string, any>,
+                children?: Record<string, any>) {
+        if (!json) {
+            return;
+        }
+
+        for (const [key, value] of Object.entries(json)) {
+            if (key.startsWith(ATTR_PREFIX)) {
+                this._fromAttrs(key, value, types);
+            } else {
+                this._fromElements(key, value, children);
+            }
+        }
+    }
+
+    /**
+     * The attributes of a Dash element (in xml) turn into members with proper data type.
+     */
+    protected _fromAttrs(key: string, value: any, types?: Record<string, any>) {
+        const attrName = key.slice(ATTR_PREFIX.length);
+        (this as any)[attrName] = types?.[attrName] ? new types[attrName](value) : value;
+    }
+
+    /**
+     * The Dash element (in xml) turns into an instance of the corresponding class.
+     */
+    protected _fromElements(key: string, value: any, children?: Record<string, any>) {
+        const className = key.charAt(0).toLowerCase() + key.slice(1);
+
+        if (ArrayTypes.includes(key)) {
+            this._buildArray(`${className}s`, key, value, children);
+            return;
+        }
+
+        (this as any)[className] = this._buildObject(key, value, children);
+    }
+
+    private _buildArray(className: string, key: string,
+                        value: any, children?: Record<string, any>) {
+        (this as any)[className] = [];
+        const arrayMember: any[] = (this as any)[className];
+
+        if (Array.isArray(value)) {
+            for (const item of value) {
+                arrayMember.push(this._buildObject(key, item, children));
+            }
+        } else {
+            arrayMember.push(this._buildObject(key, value, children));
+        }
+    }
+
+    private _buildObject(key: string, value: any, children?: Record<string, any>): any {
+        return children?.[key] ? new (children as any)[key](value) : value;
+    }
+}

--- a/src/model/data-types.ts
+++ b/src/model/data-types.ts
@@ -1,0 +1,37 @@
+
+export class Duration {
+    constructor(public value: string) {
+    }
+}
+
+/**
+ * This is a map of the Dash element names to the corresponding data types.
+ */
+export const MPD_TYPES: Record<string, Record<string, any>> = {
+    MPD: {
+        maxSegmentDuration: Duration,
+        minBufferTime: Duration,
+        minUpdatePeriod: Duration,
+        mediaPresentationDuration: Duration,
+    },
+    Period: {
+        start: Duration,
+    },
+    Representation: {
+        //
+    },
+    SegmentBase: {
+        //
+    },
+    SegmentList: {
+        //
+    },
+    SegmentTemplate: {
+        //
+    }
+};
+
+export const ArrayTypes: string[] = [
+    'Period',
+    'ProgramInformation',
+];

--- a/src/model/mpd.ts
+++ b/src/model/mpd.ts
@@ -1,0 +1,40 @@
+import ModelBase from './base';
+import { Duration, MPD_TYPES } from './data-types';
+import Period from './period';
+import ProgramInformation from './program-info';
+
+const children = {
+    Period,
+    ProgramInformation
+};
+
+/**
+ * This class represents the MPD element in DASH.
+ * @see ISO/IEC 23009-1:2022, 5.3.1 MPD element
+ */
+export default class Mpd extends ModelBase {
+    public readonly id?: string;
+    public readonly profiles: string;
+    public readonly type: string;
+    public readonly availabilityStartTime?: Date;
+    public readonly publishTime?: Date;
+    public readonly availabilityEndTime?: Date;
+    public readonly mediaPresentationDuration?: Duration;
+    public readonly timeShiftBufferDepth?: Duration;
+    public readonly suggestedPresentationDelay?: Duration;
+    public readonly minimumUpdatePeriod?: Duration;
+    public readonly dynamic?: boolean;
+    public readonly location?: string;
+    public readonly minBufferTime: Duration;
+    public readonly maxSegmentDuration?: Duration;
+    public readonly programInformation?: ProgramInformation;
+    public readonly periods: Period[];
+
+    constructor(json: Record<string, any>) {
+        super(json, MPD_TYPES.MPD, children);
+        this.profiles ??= '';
+        this.type ??= 'static';
+        this.minBufferTime ??= new Duration('');
+        this.periods ??= [];
+    }
+}

--- a/src/model/period.ts
+++ b/src/model/period.ts
@@ -1,0 +1,12 @@
+import ModelBase from './base';
+import { MPD_TYPES } from './data-types';
+
+/**
+ * This class represents the Period element in DASH.
+ * @see ISO/IEC 23009-1:2014, 5.3.2 Period element
+ */
+export default class Period extends ModelBase {
+    constructor(json: Record<string, any>) {
+        super(json, MPD_TYPES.Period, {});
+    }
+}

--- a/src/model/program-info.ts
+++ b/src/model/program-info.ts
@@ -1,0 +1,14 @@
+import ModelBase from './base';
+
+/**
+ * Descriptive information about the program
+ * @see ISO/IEC 23009-1:2022, 5.7:
+ */
+export default class ProgramInformation extends ModelBase {
+    public readonly lang?: string;
+    public readonly moreInformationURL?: URL;
+    public readonly title?: string;
+    public readonly source?: string;
+    public readonly language?: string;
+    public readonly copyright?: string;
+}

--- a/src/services/mpd-parser.ts
+++ b/src/services/mpd-parser.ts
@@ -1,0 +1,16 @@
+import { XMLParser } from 'fast-xml-parser';
+import { ATTR_PREFIX } from '../constants';
+
+export default class MpdParser {
+    private _parser: XMLParser | null = null;
+
+    public parse(xml: string): any {
+        this._parser ??= new XMLParser({
+            ignoreAttributes: false,
+            attributeNamePrefix: ATTR_PREFIX,
+        });
+
+        const json = this._parser.parse(xml);
+        return json.MPD;
+    }
+}


### PR DESCRIPTION
## Purpose

This PR integrates a xml to json parser to parse MPD. The parsed MPD json is used to build the Dash model objects. 

## Changes

- `fast-xml-parser` module is used to parse xml and convert to json. 
- The mpd json is used to build the model starting from the root object `MPD`. 
- Every model class extends from `ModelBase` which has methods to automatically add the members from the attributes and elements in the json. 
- Each model class should adhere to the Dash spec. (Names should match but can be in camelcase. The array members will have a `s` at the end. Ex: `periods` for `Period` element in the spec). 

## todos

- The basic data types like `Duration`, `Descriptor` etc are yet to be defined. 
- Model classes need to be added. 

## References

ISO-IEC-23009-1-2022 specifications
