### PR TITLE
Create native player (audio/video tags) and attach MSE

### DIFF
--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -3,6 +3,7 @@ import Loader from '../services/loader';
 import log from 'loglevel';
 import MpdParser from '../services/mpd-parser';
 import Media from '../model/media';
+import NativePlayer from './native-player';
 
 log.setLevel('debug');
 
@@ -17,17 +18,25 @@ enum DPlayerState {
 export default class DharaPlayerController extends EventEmitter {
     private _state: DPlayerState = DPlayerState.INITIAL;
     private readonly _loader: Loader = new Loader();
-    private _media: Media | null = null;
+    private readonly _media: Media = new Media();
+    private _nativePlayer: NativePlayer | null = null;
+
+    constructor(private readonly _playerContainer: HTMLElement) {
+        super();
+    }
 
     public async setSource(sourceUrl: URL) {
         log.info(`[Controller] MPD URL = ${sourceUrl}`);
-        this._media = new Media(sourceUrl);
+        this._media.srcUrl = sourceUrl;
         this.setState(DPlayerState.FETCHING_SRC, { sourceUrl });
     }
 
     public destroy() {
         super.removeAllListeners();
         this._state = DPlayerState.INITIAL;
+        this._nativePlayer?.destroy();
+        this._nativePlayer = null;
+        this._media.destroy();
     }
 
     private async setState(state: DPlayerState, data?: any) {
@@ -65,7 +74,9 @@ export default class DharaPlayerController extends EventEmitter {
             return;
         }
 
-        this._media?.build(new MpdParser().parse(data.metadata));
+        this._media.build(new MpdParser().parse(data.metadata));
+
+        this._nativePlayer = new NativePlayer(this._media.type, this._playerContainer);
     }
 
     private _onReady() {

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 import Loader from '../services/loader';
 import log from 'loglevel';
 import MpdParser from '../services/mpd-parser';
-import Mpd from '../model/mpd';
+import Media from '../model/media';
 
 log.setLevel('debug');
 
@@ -17,9 +17,11 @@ enum DPlayerState {
 export default class DharaPlayerController extends EventEmitter {
     private _state: DPlayerState = DPlayerState.INITIAL;
     private readonly _loader: Loader = new Loader();
+    private _media: Media | null = null;
 
     public async setSource(sourceUrl: URL) {
         log.info(`[Controller] MPD URL = ${sourceUrl}`);
+        this._media = new Media(sourceUrl);
         this.setState(DPlayerState.FETCHING_SRC, { sourceUrl });
     }
 
@@ -63,9 +65,7 @@ export default class DharaPlayerController extends EventEmitter {
             return;
         }
 
-        const mpdJson = new MpdParser().parse(data.metadata);
-        const mpd = new Mpd(mpdJson);
-        log.debug(mpd);
+        this._media?.build(new MpdParser().parse(data.metadata));
     }
 
     private _onReady() {

--- a/src/controller/native-player.ts
+++ b/src/controller/native-player.ts
@@ -1,0 +1,23 @@
+import type { MediaType } from '../model/media';
+
+type MediaElement = HTMLAudioElement | HTMLVideoElement | null;
+
+export default class NativePlayer {
+    private _mediaElement: MediaElement = null;
+
+    constructor(private readonly _type: MediaType,
+                private readonly _playerContainer: HTMLElement) {
+        this._mediaElement = document.createElement(this._type) as MediaElement;
+        if (this._mediaElement) {
+            this._mediaElement.controls = true;
+            this._playerContainer.appendChild(this._mediaElement);
+        }
+    }
+
+    public destroy() {
+        if (this._mediaElement) {
+            this._playerContainer.removeChild(this._mediaElement);
+            this._mediaElement = null;
+        }
+    }
+}

--- a/src/controller/native-player.ts
+++ b/src/controller/native-player.ts
@@ -1,4 +1,4 @@
-import type { MediaType } from '../model/media';
+import { MediaType } from '../model/media';
 
 type MediaElement = HTMLAudioElement | HTMLVideoElement | null;
 
@@ -11,6 +11,13 @@ export default class NativePlayer {
         if (this._mediaElement) {
             this._mediaElement.controls = true;
             this._playerContainer.appendChild(this._mediaElement);
+            if (this._type === MediaType.VIDEO) {
+                const videoElement  = this._mediaElement as HTMLVideoElement;
+                videoElement.width  = this._playerContainer.clientWidth;
+                videoElement.height = this._playerContainer.clientHeight;
+                videoElement.style.width = '100%';
+                videoElement.style.height = '100%';
+            }
         }
     }
 

--- a/src/controller/native-player.ts
+++ b/src/controller/native-player.ts
@@ -1,30 +1,62 @@
 import { MediaType } from '../model/media';
+import log from 'loglevel';
 
 type MediaElement = HTMLAudioElement | HTMLVideoElement | null;
 
 export default class NativePlayer {
     private _mediaElement: MediaElement = null;
+    private _mediaSource: MediaSource | null = null;
 
     constructor(private readonly _type: MediaType,
                 private readonly _playerContainer: HTMLElement) {
-        this._mediaElement = document.createElement(this._type) as MediaElement;
-        if (this._mediaElement) {
-            this._mediaElement.controls = true;
-            this._playerContainer.appendChild(this._mediaElement);
-            if (this._type === MediaType.VIDEO) {
-                const videoElement  = this._mediaElement as HTMLVideoElement;
-                videoElement.width  = this._playerContainer.clientWidth;
-                videoElement.height = this._playerContainer.clientHeight;
-                videoElement.style.width = '100%';
-                videoElement.style.height = '100%';
-            }
-        }
+        this._createPlayer();
+        this._createMediaSource();
     }
 
     public destroy() {
         if (this._mediaElement) {
             this._playerContainer.removeChild(this._mediaElement);
             this._mediaElement = null;
+        }
+
+        if (this._mediaSource) {
+            if (this._mediaSource.readyState === 'open') {
+                this._mediaSource.endOfStream();
+            }
+            this._mediaSource = null;
+        }
+    }
+
+    private _createPlayer() {
+        this._mediaElement = document.createElement(this._type) as MediaElement;
+        if (!this._mediaElement) {
+            return;
+        }
+
+        this._mediaElement.controls = true;
+        this._playerContainer.appendChild(this._mediaElement);
+
+        if (this._type === MediaType.VIDEO) {
+            const videoElement  = this._mediaElement as HTMLVideoElement;
+            videoElement.width  = this._playerContainer.clientWidth;
+            videoElement.height = this._playerContainer.clientHeight;
+            videoElement.style.width = '100%';
+            videoElement.style.height = '100%';
+        }
+    }
+
+    private _createMediaSource() {
+        if (!this._mediaElement || !window.MediaSource) {
+            log.error('MediaSource not supported or media element not available');
+            return;
+        }
+
+        try {
+            this._mediaSource = new MediaSource();
+            this._mediaElement.src = URL.createObjectURL(this._mediaSource);
+        } catch (error) {
+            log.error('Failed to create MediaSource', error);
+            return;
         }
     }
 }

--- a/src/dhara-player.ts
+++ b/src/dhara-player.ts
@@ -1,12 +1,10 @@
 import DharaPlayerController from './controller/controller';
 
 export default class DharaPlayer {
-    private readonly _playerContainer: HTMLElement;
     private readonly _controller: DharaPlayerController;
 
     constructor(playerContainer: HTMLElement) {
-        this._playerContainer = playerContainer;
-        this._controller = new DharaPlayerController();
+        this._controller = new DharaPlayerController(playerContainer);
     }
 
     public setSource(sourceUrl: URL) {

--- a/src/html/index-template.html
+++ b/src/html/index-template.html
@@ -10,8 +10,8 @@
 </head>
 
 <body>
-    <div id="player-container">
-        <h1>Dhara Player</h1>
+    <h1>Dhara Player</h1>
+    <div id="player-container" style="width: 640px; height: 360px;">
     </div>
 
     <script>

--- a/src/html/index-template.html
+++ b/src/html/index-template.html
@@ -17,8 +17,8 @@
     <script>
         const playerContainer = document.getElementById('player-container');
         const player = new window.DHARA.Player(playerContainer);
-        player.setSource(new URL('https://livesim2.dashif.org/vod/testpic_2s/audio.mpd'));
-        // player.setSource(new URL('https://dash.akamaized.net/dash264/TestCases/5a/nomor/1.mpd'));
+        // player.setSource(new URL('https://livesim2.dashif.org/vod/testpic_2s/audio.mpd'));
+        player.setSource(new URL('https://dash.akamaized.net/dash264/TestCases/5a/nomor/1.mpd'));
     </script>
 </body>
 

--- a/src/model/media.ts
+++ b/src/model/media.ts
@@ -1,15 +1,42 @@
 import Mpd from './mpd';
 import log from 'loglevel';
+import type AdaptationSet from './adaptation-set';
+import type Representation from './representation';
+
+export enum MediaType {
+    AUDIO = 'audio',
+    VIDEO = 'video',
+    UNKNOWN = 'unknown',
+}
 
 export default class Media {
+    public srcUrl?: URL;
     private _mpd: Mpd | null = null;
-
-    constructor(public srcUrl: URL) {
-        //
-    }
+    private _type: MediaType = MediaType.UNKNOWN;
 
     public build(metadata: Record<string, any>) {
         this._mpd = new Mpd(metadata);
         log.debug(this._mpd);
+    }
+
+    public get type(): MediaType {
+        if (this._type !== MediaType.UNKNOWN) {
+            return this._type;
+        }
+
+        this._type = this._mpd?.periods?.[0]?.type ?? MediaType.UNKNOWN;
+        return this._type;
+    }
+
+    public destroy() {
+        this._mpd = null;
+    }
+
+    public getAdaptationSets(periodIndex: number = 0): AdaptationSet[] {
+        return this._mpd?.periods?.[periodIndex]?.adaptationSets ?? [];
+    }
+
+    public getRepresentations(periodIndex: number = 0): Representation[] {
+        return this._mpd?.periods?.[periodIndex]?.adaptationSets?.[0]?.representations ?? [];
     }
 }

--- a/src/model/media.ts
+++ b/src/model/media.ts
@@ -1,0 +1,15 @@
+import Mpd from './mpd';
+import log from 'loglevel';
+
+export default class Media {
+    private _mpd: Mpd | null = null;
+
+    constructor(public srcUrl: URL) {
+        //
+    }
+
+    public build(metadata: Record<string, any>) {
+        this._mpd = new Mpd(metadata);
+        log.debug(this._mpd);
+    }
+}

--- a/src/model/period.ts
+++ b/src/model/period.ts
@@ -4,6 +4,7 @@ import SegmentBase from './segment-base';
 import SegmentList from './segment-list';
 import SegmentTemplate from './segment-template';
 import AdaptationSet from './adaptation-set';
+import { MediaType } from './media';
 
 const typeMap = {
     start: DashTypes.Duration,
@@ -46,5 +47,42 @@ export default class Period extends ModelBase {
         this.baseURLs = this._buildArray(URL, 'BaseURL');
 
         this._init();
+    }
+
+    public get type(): MediaType {
+        let typeId = 0;
+        const adaptationSets = this.adaptationSets ?? [];
+
+        // Get type from the content type in adaptation set if available:
+        if (adaptationSets?.[0]?.contentType) {
+            for (const adaptationSet of adaptationSets) {
+                if (adaptationSet.contentType?.startsWith('video')) {
+                    typeId += 2;
+                    break;
+                } else if (adaptationSet.contentType?.startsWith('audio')) {
+                    typeId += 1;
+                }
+            }
+
+            return typeId === 3 ? MediaType.VIDEO : MediaType.AUDIO;
+        }
+
+        // Get type from the mime type in representation if available:
+        const firstRepresentation = adaptationSets?.[0]?.representations?.[0];
+        if (!firstRepresentation?.mimeType) {
+            return MediaType.UNKNOWN;
+        }
+
+        for (const adaptationSet of adaptationSets) {
+            const mimeType = adaptationSet.representations?.[0]?.mimeType;
+            if (mimeType?.startsWith('video')) {
+                typeId += 2;
+                break;
+            } else if (mimeType?.startsWith('audio')) {
+                typeId += 1;
+            }
+        }
+
+        return typeId === 3 ? MediaType.VIDEO : MediaType.AUDIO;
     }
 }

--- a/src/model/period.ts
+++ b/src/model/period.ts
@@ -64,7 +64,7 @@ export default class Period extends ModelBase {
                 }
             }
 
-            return typeId === 3 ? MediaType.VIDEO : MediaType.AUDIO;
+            return typeId >= 2 ? MediaType.VIDEO : MediaType.AUDIO;
         }
 
         // Get type from the mime type in representation if available:
@@ -83,6 +83,6 @@ export default class Period extends ModelBase {
             }
         }
 
-        return typeId === 3 ? MediaType.VIDEO : MediaType.AUDIO;
+        return typeId >= 2 ? MediaType.VIDEO : MediaType.AUDIO;
     }
 }

--- a/src/model/representation.ts
+++ b/src/model/representation.ts
@@ -17,6 +17,7 @@ export default class Representation extends ModelBase {
     public readonly associationType?: string;
     public readonly mediaStreamStructureId?: string;
     public readonly bandwidth: number;
+    public readonly mimeType?: string;
 
     /**
      * To add: BaseURL, ExtendedBandwidth, SubRepresentation,


### PR DESCRIPTION
## Purpose

This PR creates native video or audio elements and appends it to the DOM node being input. Then it creates a MediaSource and attaches it to the element. If the MPD contains only audio, then audio only player (<audio>) will be created. 

## Changes

- Creates `NativePlayer` which encapsulates the native audio/video elements. 
- This class also owns the `MediaSource` instance. 
- Creates `Media` class that is the interface for all media model classes. 
