### PR TITLE
Player is ready for streaming

### DIFF
--- a/src/controller/native-player.ts
+++ b/src/controller/native-player.ts
@@ -1,14 +1,23 @@
+import { EventEmitter } from 'events';
 import { MediaType } from '../model/media';
 import log from 'loglevel';
 
 type MediaElement = HTMLAudioElement | HTMLVideoElement | null;
 
-export default class NativePlayer {
+export enum NativePlayerEvent {
+    SOURCE_OPEN  = 'sourceopen',
+    SOURCE_CLOSE = 'sourceclose',
+    SOURCE_ENDED = 'sourceended',
+    ERROR        = 'error',
+}
+
+export default class NativePlayer extends EventEmitter {
     private _mediaElement: MediaElement = null;
     private _mediaSource: MediaSource | null = null;
 
     constructor(private readonly _type: MediaType,
                 private readonly _playerContainer: HTMLElement) {
+        super();
         this._createPlayer();
         this._createMediaSource();
     }
@@ -23,8 +32,15 @@ export default class NativePlayer {
             if (this._mediaSource.readyState === 'open') {
                 this._mediaSource.endOfStream();
             }
+
+            this._mediaSource.removeEventListener('sourceopen',  this._onSourceOpen.bind(this));
+            this._mediaSource.removeEventListener('sourceclose', this._onSourceClose.bind(this));
+            this._mediaSource.removeEventListener('sourceended', this._onSourceEnded.bind(this));
+
             this._mediaSource = null;
         }
+
+        this.removeAllListeners();
     }
 
     private _createPlayer() {
@@ -47,16 +63,50 @@ export default class NativePlayer {
 
     private _createMediaSource() {
         if (!this._mediaElement || !window.MediaSource) {
-            log.error('MediaSource not supported or media element not available');
+            this._onError('MediaSource not supported or media element not available');
             return;
         }
 
         try {
             this._mediaSource = new MediaSource();
-            this._mediaElement.src = URL.createObjectURL(this._mediaSource);
         } catch (error) {
-            log.error('Failed to create MediaSource', error);
+            this._onError('Failed to create MediaSource', error);
             return;
         }
+
+        this._mediaSource.addEventListener('sourceopen',  this._onSourceOpen.bind(this));
+        this._mediaSource.addEventListener('sourceclose', this._onSourceClose.bind(this));
+        this._mediaSource.addEventListener('sourceended', this._onSourceEnded.bind(this));
+
+        if ('srcObject' in this._mediaElement) {
+            try {
+                this._mediaElement.srcObject = this._mediaSource;
+            } catch (error: unknown) {
+                if (error instanceof Error && error.name !== 'TypeError') {
+                    this._onError('Failed to set srcObject', error);
+                    return;
+                }
+                this._mediaElement.src = URL.createObjectURL(this._mediaSource);
+            }
+        } else {
+            (this._mediaElement as HTMLAudioElement | HTMLVideoElement).src = URL.createObjectURL(this._mediaSource);
+        }
+    }
+
+    private _onSourceOpen() {
+        this.emit(NativePlayerEvent.SOURCE_OPEN);
+    }
+
+    private _onSourceClose() {
+        this.emit(NativePlayerEvent.SOURCE_CLOSE);
+    }
+
+    private _onSourceEnded() {
+        this.emit(NativePlayerEvent.SOURCE_ENDED);
+    }
+
+    private _onError(errMsg: string, error: unknown = null) {
+        log.error(errMsg, error);
+        this.emit(NativePlayerEvent.ERROR, errMsg);
     }
 }


### PR DESCRIPTION
## Purpose

In this PR, we add event handlers to MediaSource. When media source is in `open` state, then the player gets into `READY` state. This indicates that the player is ready to start streaming and fill in the source buffers. 

## Changes

- Attaching `MediaSource` to the media element is fixed to handle both the new and old methods. 
- Added event handlers to media source events. 
- Added event listeners to the `NativePlayer` events in controller. 
- In controller, transit to the READY state if media source is open or transit to the error state if there was an error. 
