### PR TITLE
Create streamers and streaming engine

### DIFF
--- a/src/controller/native-player.ts
+++ b/src/controller/native-player.ts
@@ -11,6 +11,12 @@ export enum NativePlayerEvent {
     ERROR        = 'error',
 }
 
+export enum MediaSourceReadyState {
+    CLOSED = 'closed',
+    OPEN   = 'open',
+    ENDED  = 'ended',
+}
+
 export default class NativePlayer extends EventEmitter {
     private _mediaElement: MediaElement = null;
     private _mediaSource: MediaSource | null = null;
@@ -41,6 +47,10 @@ export default class NativePlayer extends EventEmitter {
         }
 
         this.removeAllListeners();
+    }
+
+    public get readyState(): MediaSourceReadyState {
+        return (this._mediaSource?.readyState as MediaSourceReadyState) ?? MediaSourceReadyState.CLOSED;
     }
 
     private _createPlayer() {

--- a/src/controller/streamers/audio-streamer.ts
+++ b/src/controller/streamers/audio-streamer.ts
@@ -1,0 +1,10 @@
+import Streamer from './streamer';
+
+/**
+ * AudioStreamer is a subclass of Streamer that handles the streaming of an audio stream.
+ */
+export default class AudioStreamer extends Streamer {
+    public destroy() {
+        super.destroy();
+    }
+}

--- a/src/controller/streamers/muxed-streamer.ts
+++ b/src/controller/streamers/muxed-streamer.ts
@@ -1,0 +1,11 @@
+import Streamer from './streamer';
+
+/**
+ * MuxedStreamer is a subclass of Streamer that handles the streaming of a muxed stream.
+ * A muxed stream contains both audio and video.
+ */
+export default class MuxedStreamer extends Streamer {
+    public destroy() {
+        super.destroy();
+    }
+}

--- a/src/controller/streamers/streamer-factory.ts
+++ b/src/controller/streamers/streamer-factory.ts
@@ -1,0 +1,23 @@
+import type Media from '../../model/media';
+import type NativePlayer from '../native-player';
+import { StreamType } from '../../model/adaptation-set';
+import type Streamer from './streamer';
+import VideoStreamer from './video-streamer';
+import AudioStreamer from './audio-streamer';
+import TextStreamer  from './text-streamer';
+import MuxedStreamer from './muxed-streamer';
+
+export function create(streamType: StreamType, media: Media, nativePlayer: NativePlayer): Streamer {
+    switch (streamType) {
+        case StreamType.VIDEO:
+            return new VideoStreamer(media, nativePlayer);
+        case StreamType.AUDIO:
+            return new AudioStreamer(media, nativePlayer);
+        case StreamType.TEXT:
+            return new TextStreamer(media, nativePlayer);
+        case StreamType.MUXED:
+            return new MuxedStreamer(media, nativePlayer);
+        default:
+            throw new Error(`Unsupported stream type: ${streamType}`);
+    }
+}

--- a/src/controller/streamers/streamer.ts
+++ b/src/controller/streamers/streamer.ts
@@ -1,0 +1,21 @@
+import type Media from '../../model/media';
+import type NativePlayer from '../native-player';
+
+/**
+ * Streamer is a class that handles the streaming of a media stream.
+ * It is responsible for managing the appropriate source buffers for the stream.
+ * This is a base class for all streamers.
+ */
+export default class Streamer {
+    protected readonly _media: Media;
+    protected readonly _nativePlayer: NativePlayer;
+
+    constructor(media: Media, nativePlayer: NativePlayer) {
+        this._media = media;
+        this._nativePlayer = nativePlayer;
+    }
+
+    public destroy() {
+        //
+    }
+}

--- a/src/controller/streamers/text-streamer.ts
+++ b/src/controller/streamers/text-streamer.ts
@@ -1,0 +1,10 @@
+import Streamer from './streamer';
+
+/**
+ * TextStreamer is a subclass of Streamer that handles the streaming of a text stream.
+ */
+export default class TextStreamer extends Streamer {
+    public destroy() {
+        super.destroy();
+    }
+}

--- a/src/controller/streamers/video-streamer.ts
+++ b/src/controller/streamers/video-streamer.ts
@@ -1,0 +1,10 @@
+import Streamer from './streamer';
+
+/**
+ * VideoStreamer is a subclass of Streamer that handles the streaming of a video stream.
+ */
+export default class VideoStreamer extends Streamer {
+    public destroy() {
+        super.destroy();
+    }
+}

--- a/src/controller/streaming-engine.ts
+++ b/src/controller/streaming-engine.ts
@@ -1,0 +1,48 @@
+import { EventEmitter } from 'events';
+import type Media from '../model/media';
+import type NativePlayer from './native-player';
+import { MediaSourceReadyState, NativePlayerEvent } from './native-player';
+import type Streamer from './streamers/streamer';
+import * as StreamerFactory from './streamers/streamer-factory';
+import { StreamType } from '../model/adaptation-set';
+
+export enum StreamingEngineEvent {
+    ERROR = 'error',
+}
+
+export default class StreamingEngine extends EventEmitter {
+    private readonly _media: Media;
+    private readonly _nativePlayer: NativePlayer;
+    private _streamers: Streamer[] = [];
+
+    constructor(media: Media, nativePlayer: NativePlayer) {
+        super();
+        this._media = media;
+        this._nativePlayer = nativePlayer;
+
+        if (this._nativePlayer.readyState === MediaSourceReadyState.OPEN) {
+            this._initialize();
+        } else {
+            this._nativePlayer.on(NativePlayerEvent.SOURCE_OPEN, this._initialize.bind(this));
+        }
+    }
+
+    public destroy() {
+        this.removeAllListeners();
+        for (const streamer of this._streamers) {
+            streamer.destroy();
+        }
+        this._streamers = [];
+    }
+
+    private _initialize() {
+        for (const adaptationSet of this._media.getAdaptationSets()) {
+            const streamType = adaptationSet.streamType;
+            if (streamType === StreamType.UNKNOWN) {
+                continue;
+            }
+
+            this._streamers.push( StreamerFactory.create(streamType, this._media, this._nativePlayer) );
+        }
+    }
+}

--- a/src/model/media.ts
+++ b/src/model/media.ts
@@ -2,6 +2,7 @@ import Mpd from './mpd';
 import log from 'loglevel';
 import type AdaptationSet from './adaptation-set';
 import type Representation from './representation';
+import { StreamType } from './adaptation-set';
 
 export enum MediaType {
     AUDIO = 'audio',
@@ -24,7 +25,22 @@ export default class Media {
             return this._type;
         }
 
-        this._type = this._mpd?.periods?.[0]?.type ?? MediaType.UNKNOWN;
+        const adaptationSets = this.getAdaptationSets() ?? [];
+        let hasAudio = false;
+
+        for (const adaptationSet of adaptationSets) {
+            const streamType = adaptationSet.streamType;
+            if (streamType === StreamType.AUDIO) {
+                hasAudio = true;
+                continue;
+            }
+            if (streamType === StreamType.VIDEO || streamType === StreamType.MUXED) {
+                this._type = MediaType.VIDEO;
+                return this._type;
+            }
+        }
+
+        this._type = hasAudio ? MediaType.AUDIO : MediaType.UNKNOWN;
         return this._type;
     }
 

--- a/src/model/period.ts
+++ b/src/model/period.ts
@@ -4,7 +4,6 @@ import SegmentBase from './segment-base';
 import SegmentList from './segment-list';
 import SegmentTemplate from './segment-template';
 import AdaptationSet from './adaptation-set';
-import { MediaType } from './media';
 
 const typeMap = {
     start: DashTypes.Duration,
@@ -47,42 +46,5 @@ export default class Period extends ModelBase {
         this.baseURLs = this._buildArray(URL, 'BaseURL');
 
         this._init();
-    }
-
-    public get type(): MediaType {
-        let typeId = 0;
-        const adaptationSets = this.adaptationSets ?? [];
-
-        // Get type from the content type in adaptation set if available:
-        if (adaptationSets?.[0]?.contentType) {
-            for (const adaptationSet of adaptationSets) {
-                if (adaptationSet.contentType?.startsWith('video')) {
-                    typeId += 2;
-                    break;
-                } else if (adaptationSet.contentType?.startsWith('audio')) {
-                    typeId += 1;
-                }
-            }
-
-            return typeId >= 2 ? MediaType.VIDEO : MediaType.AUDIO;
-        }
-
-        // Get type from the mime type in representation if available:
-        const firstRepresentation = adaptationSets?.[0]?.representations?.[0];
-        if (!firstRepresentation?.mimeType) {
-            return MediaType.UNKNOWN;
-        }
-
-        for (const adaptationSet of adaptationSets) {
-            const mimeType = adaptationSet.representations?.[0]?.mimeType;
-            if (mimeType?.startsWith('video')) {
-                typeId += 2;
-                break;
-            } else if (mimeType?.startsWith('audio')) {
-                typeId += 1;
-            }
-        }
-
-        return typeId >= 2 ? MediaType.VIDEO : MediaType.AUDIO;
     }
 }


### PR DESCRIPTION
## Purpose

This PR implements a streaming engine. It creates and owns a bunch of streamers. Each streamer manages one type of stream (ex: audioStreamer). A streamer loads the appropriate segments, post process it, and appends the content to the attached source buffer. Each streamer manages one source buffer. Therefore, streamer is similar to `Track` in a video/audio element. 

## Changes

- Implements an initial version of `StreamingEngine`
- Defines a bunch of streamer classes. 
- Defines a base `Streamer` class. 
- Implements streamer factory function. 
- Moved the `type` getter from `Period` to `Media` and simplified it. 
