### PR TITLE
Add source buffers to the media src

### DIFF
--- a/src/controller/native-player.ts
+++ b/src/controller/native-player.ts
@@ -53,6 +53,10 @@ export default class NativePlayer extends EventEmitter {
         return (this._mediaSource?.readyState as MediaSourceReadyState) ?? MediaSourceReadyState.CLOSED;
     }
 
+    public get mediaSource(): MediaSource | null {
+        return this._mediaSource;
+    }
+
     private _createPlayer() {
         this._mediaElement = document.createElement(this._type) as MediaElement;
         if (!this._mediaElement) {

--- a/src/controller/streamers/buffer.ts
+++ b/src/controller/streamers/buffer.ts
@@ -1,0 +1,11 @@
+export default class Buffer {
+    private readonly _srcBuffer: SourceBuffer;
+
+    constructor(mimeCodec: string, mediaSource: MediaSource) {
+        this._srcBuffer = mediaSource.addSourceBuffer(mimeCodec);
+    }
+
+    public destroy() {
+        // this._srcBuffer.remove();
+    }
+}

--- a/src/controller/streamers/streamer-factory.ts
+++ b/src/controller/streamers/streamer-factory.ts
@@ -1,5 +1,6 @@
 import type Media from '../../model/media';
 import type NativePlayer from '../native-player';
+import type AdaptationSet from '../../model/adaptation-set';
 import { StreamType } from '../../model/adaptation-set';
 import type Streamer from './streamer';
 import VideoStreamer from './video-streamer';
@@ -7,16 +8,16 @@ import AudioStreamer from './audio-streamer';
 import TextStreamer  from './text-streamer';
 import MuxedStreamer from './muxed-streamer';
 
-export function create(streamType: StreamType, media: Media, nativePlayer: NativePlayer): Streamer {
+export function create(streamType: StreamType, media: Media, adaptationSet: AdaptationSet, nativePlayer: NativePlayer): Streamer {
     switch (streamType) {
         case StreamType.VIDEO:
-            return new VideoStreamer(media, nativePlayer);
+            return new VideoStreamer(media, adaptationSet, nativePlayer);
         case StreamType.AUDIO:
-            return new AudioStreamer(media, nativePlayer);
+            return new AudioStreamer(media, adaptationSet, nativePlayer);
         case StreamType.TEXT:
-            return new TextStreamer(media, nativePlayer);
+            return new TextStreamer(media, adaptationSet, nativePlayer);
         case StreamType.MUXED:
-            return new MuxedStreamer(media, nativePlayer);
+            return new MuxedStreamer(media, adaptationSet, nativePlayer);
         default:
             throw new Error(`Unsupported stream type: ${streamType}`);
     }

--- a/src/controller/streamers/streamer.ts
+++ b/src/controller/streamers/streamer.ts
@@ -1,5 +1,8 @@
 import type Media from '../../model/media';
+import type AdaptationSet from '../../model/adaptation-set';
 import type NativePlayer from '../native-player';
+import Buffer from './buffer';
+import log from 'loglevel';
 
 /**
  * Streamer is a class that handles the streaming of a media stream.
@@ -9,13 +12,39 @@ import type NativePlayer from '../native-player';
 export default class Streamer {
     protected readonly _media: Media;
     protected readonly _nativePlayer: NativePlayer;
+    protected readonly _adaptationSet: AdaptationSet;
+    protected _buffer: Buffer | null = null;
 
-    constructor(media: Media, nativePlayer: NativePlayer) {
+    constructor(media: Media, adaptationSet: AdaptationSet, nativePlayer: NativePlayer) {
         this._media = media;
         this._nativePlayer = nativePlayer;
+        this._adaptationSet = adaptationSet;
+    }
+
+    public initialize(): boolean {
+        const mimeType  = this._adaptationSet.getMimeType();
+        const codecs    = this._adaptationSet.getCodecs();
+        const mimeCodec = `${mimeType}; codecs="${codecs}"`;
+        const mediaSource = this._nativePlayer.mediaSource;
+
+        if (!mediaSource) {
+            log.warn(`[Streamer] No media source found`);
+            return false;
+        }
+
+        try {
+            this._buffer = new Buffer(mimeCodec, mediaSource);
+        } catch (error) {
+            log.error(`[Streamer] Failed to create buffer for ${mimeCodec}`);
+            log.error(error);
+            return false;
+        }
+
+        return true;
     }
 
     public destroy() {
-        //
+        this._buffer?.destroy();
+        this._buffer = null;
     }
 }

--- a/src/controller/streaming-engine.ts
+++ b/src/controller/streaming-engine.ts
@@ -42,7 +42,10 @@ export default class StreamingEngine extends EventEmitter {
                 continue;
             }
 
-            this._streamers.push( StreamerFactory.create(streamType, this._media, this._nativePlayer) );
+            const streamer = StreamerFactory.create(streamType, this._media, adaptationSet, this._nativePlayer);
+            if (streamer.initialize()) {
+                this._streamers.push(streamer);
+            }
         }
     }
 }

--- a/src/model/adaptation-set.ts
+++ b/src/model/adaptation-set.ts
@@ -54,6 +54,9 @@ export default class AdaptationSet extends ModelBase {
     public readonly segmentTemplate?: SegmentTemplate;
     public readonly representations?: Representation[];
     public readonly mimeType?: string; // part of RepresentationBase - move this later
+    public readonly codecs?: string; // part of RepresentationBase - move this later
+
+    private readonly _firstRepresentation?: Representation | null;
 
     /**
      * To add: par, subsegmentStartsWithSAP, initializationSetRef, initializationPrincipal,
@@ -68,14 +71,14 @@ export default class AdaptationSet extends ModelBase {
 
         this.representations = this._buildArray(Representation, 'Representation');
         this.baseURLs = this._buildArray(URL, 'BaseURL');
+        this._firstRepresentation = this.representations?.[0] ?? null;
 
         this._init();
     }
 
     public get streamType(): StreamType {
-        const firstRepresentation = this.representations?.[0];
         const contentType = this.contentType?.toLowerCase();
-        const mimeType = this.mimeType?.toLowerCase() ?? firstRepresentation?.mimeType?.toLowerCase();
+        const mimeType = this.getMimeType();
 
         if (contentType?.startsWith('video') || mimeType?.startsWith('video')) {
             // The video stream could be muxed. Figure this out later.
@@ -91,5 +94,13 @@ export default class AdaptationSet extends ModelBase {
         }
 
         return StreamType.UNKNOWN;
+    }
+
+    public getMimeType(): string {
+        return this.mimeType?.toLowerCase() ?? this._firstRepresentation?.mimeType?.toLowerCase() ?? '';
+    }
+
+    public getCodecs(): string {
+        return this.codecs ?? this._firstRepresentation?.codecs ?? '';
     }
 }

--- a/src/model/representation.ts
+++ b/src/model/representation.ts
@@ -18,6 +18,7 @@ export default class Representation extends ModelBase {
     public readonly mediaStreamStructureId?: string;
     public readonly bandwidth: number;
     public readonly mimeType?: string;
+    public readonly codecs?: string;
 
     /**
      * To add: BaseURL, ExtendedBandwidth, SubRepresentation,


### PR DESCRIPTION
## Purpose

This PR creates source buffers for each track and adds them to the media source. 

## Changes

- Add a new class `Buffer` which acts as a buffer for each track. It owns and manages the source buffer for the track. 
- Create source buffer based on mimecodec and add it to the media src. 

