### PR TITLE
Hook up event listeners to the native player

### DIFF
--- a/src/controller/native-player.ts
+++ b/src/controller/native-player.ts
@@ -5,10 +5,17 @@ import log from 'loglevel';
 type MediaElement = HTMLAudioElement | HTMLVideoElement | null;
 
 export enum NativePlayerEvent {
-    SOURCE_OPEN  = 'sourceopen',
+    ERROR        = 'error',
+    ENDED        = 'ended',
+    PAUSE        = 'pause',
+    PLAY         = 'play',
+    PLAYING      = 'playing',
     SOURCE_CLOSE = 'sourceclose',
     SOURCE_ENDED = 'sourceended',
-    ERROR        = 'error',
+    SOURCE_OPEN  = 'sourceopen',
+    TIMEUPDATE   = 'timeupdate',
+    VOLUMECHANGE = 'volumechange',
+    WAITING      = 'waiting',
 }
 
 export enum MediaSourceReadyState {
@@ -73,6 +80,8 @@ export default class NativePlayer extends EventEmitter {
             videoElement.style.width = '100%';
             videoElement.style.height = '100%';
         }
+
+        this._bindEvents();
     }
 
     private _createMediaSource() {
@@ -122,5 +131,28 @@ export default class NativePlayer extends EventEmitter {
     private _onError(errMsg: string, error: unknown = null) {
         log.error(errMsg, error);
         this.emit(NativePlayerEvent.ERROR, errMsg);
+    }
+
+    private _bindEvents() {
+        if (!this._mediaElement) {
+            return;
+        }
+
+        const events = [
+            NativePlayerEvent.ERROR,
+            NativePlayerEvent.ENDED,
+            NativePlayerEvent.PAUSE,
+            NativePlayerEvent.PLAY,
+            NativePlayerEvent.PLAYING,
+            NativePlayerEvent.TIMEUPDATE,
+            NativePlayerEvent.VOLUMECHANGE,
+            NativePlayerEvent.WAITING,
+        ];
+
+        for (const event of events) {
+            this._mediaElement.addEventListener(event, (event: Event, ...args: any[]) => {
+                this.emit(event.type as NativePlayerEvent, ...args);
+            });
+        }
     }
 }

--- a/src/controller/streamers/streamer.ts
+++ b/src/controller/streamers/streamer.ts
@@ -47,4 +47,8 @@ export default class Streamer {
         this._buffer?.destroy();
         this._buffer = null;
     }
+
+    public onPlay() {
+        log.info(`[Streamer] onPlay`);
+    }
 }

--- a/src/model/base.ts
+++ b/src/model/base.ts
@@ -1,5 +1,6 @@
 import { Duration, Descriptor } from './data-types';
 import { ATTR_PREFIX } from '../constants';
+import { toCamelCase } from '../utils';
 
 export enum DashTypes {
     Duration = 0,
@@ -84,7 +85,7 @@ export default class ModelBase {
             return;
         }
 
-        const memberName = className.charAt(0).toLowerCase() + className.slice(1);
+        const memberName = toCamelCase(className);
         (this as any)[memberName] = new classDef(this.json[className]);
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,7 @@
+export function toCamelCase(str: string): string {
+    return str.charAt(0).toLowerCase() + str.slice(1);
+}
+
+export function toTitleCase(str: string): string {
+    return str.charAt(0).toUpperCase() + str.slice(1);
+}


### PR DESCRIPTION
## Purpose

This PR hooks up event listeners to the media element to listen to all the events and propagate them to the individual streamers along with the payload. Streamers deal with these events and manage streaming.

## Changes

- Attach event listeners to the media element 
- Attach event listeners to the native player in the streaming engine. 
- Propagate the event and payload to the streamer by calling appropriate method. 
