### PR TITLE
Add process tick timer

### DIFF
--- a/src/controller/streamers/streamer.ts
+++ b/src/controller/streamers/streamer.ts
@@ -1,8 +1,22 @@
 import type Media from '../../model/media';
 import type AdaptationSet from '../../model/adaptation-set';
+import type Representation from '../../model/representation';
+import type Period from '../../model/period';
+import type SegmentBase from '../../model/segment-base';
 import type NativePlayer from '../native-player';
 import Buffer from './buffer';
 import log from 'loglevel';
+
+class StreamerState {
+    public curRep: Representation | null = null;
+    public curPeriod: Period | null = null;
+    public curSegment: SegmentBase | null = null;
+    public curPeriodIndex: number = 0;
+    public curRepIndex: number = 0;
+    public curSegmentIndex: number = 0;
+}
+
+const PROCESS_TICK = 20; // in milliseconds
 
 /**
  * Streamer is a class that handles the streaming of a media stream.
@@ -14,6 +28,9 @@ export default class Streamer {
     protected readonly _nativePlayer: NativePlayer;
     protected readonly _adaptationSet: AdaptationSet;
     protected _buffer: Buffer | null = null;
+    protected _state: StreamerState = new StreamerState();
+    protected _timer: NodeJS.Timeout | null = null;
+    protected _name: string = this.constructor.name;
 
     constructor(media: Media, adaptationSet: AdaptationSet, nativePlayer: NativePlayer) {
         this._media = media;
@@ -40,6 +57,9 @@ export default class Streamer {
             return false;
         }
 
+        this._state.curPeriod = this._media.periods?.[this._state.curPeriodIndex] ?? null;
+        this._state.curRep = this._adaptationSet.representations?.[this._state.curRepIndex] ?? null;
+
         return true;
     }
 
@@ -49,6 +69,29 @@ export default class Streamer {
     }
 
     public onPlay() {
-        log.info(`[Streamer] onPlay`);
+        log.info(`[${this._name}] onPlay`);
+        this.start();
+    }
+
+    public onPause() {
+        log.info(`[${this._name}] onPause`);
+        this.stop();
+    }
+
+    public start() {
+        this._timer = setInterval(() => {
+            this._process();
+        }, PROCESS_TICK);
+    }
+
+    public stop() {
+        if (this._timer) {
+            clearInterval(this._timer);
+            this._timer = null;
+        }
+    }
+
+    protected _process() {
+        //
     }
 }

--- a/src/controller/streaming-engine.ts
+++ b/src/controller/streaming-engine.ts
@@ -52,8 +52,13 @@ export default class StreamingEngine extends EventEmitter {
         for (const event of Object.values(NativePlayerEvent)) {
             this._nativePlayer.on(event, (...args: any[]) => {
                 try {
-                    const methodName = `_on${toTitleCase(event)}`;
-                    (this as any)[methodName](...args);
+                    const handlerName = `on${toTitleCase(event)}`;
+                    const methodName  = `_${handlerName}`;
+                    if ((this as any)[methodName]) {
+                        (this as any)[methodName](...args);
+                    } else {
+                        this._sendEventToStreamers(handlerName, ...args);
+                    }
                 } catch { /* ignore */ }
             });
         }
@@ -65,13 +70,5 @@ export default class StreamingEngine extends EventEmitter {
                 (streamer as any)[methodName](...args);
             } catch { /* ignore */ }
         }
-    }
-
-    private _onPlay() {
-        this._sendEventToStreamers('onPlay');
-    }
-
-    private _onPlaying() {
-        this._sendEventToStreamers('onPlaying');
     }
 }

--- a/src/model/media.ts
+++ b/src/model/media.ts
@@ -3,6 +3,7 @@ import log from 'loglevel';
 import type AdaptationSet from './adaptation-set';
 import type Representation from './representation';
 import { StreamType } from './adaptation-set';
+import type Period from './period';
 
 export enum MediaType {
     AUDIO = 'audio',
@@ -48,11 +49,15 @@ export default class Media {
         this._mpd = null;
     }
 
+    public get periods(): Period[] {
+        return this._mpd?.periods ?? [];
+    }
+
     public getAdaptationSets(periodIndex: number = 0): AdaptationSet[] {
         return this._mpd?.periods?.[periodIndex]?.adaptationSets ?? [];
     }
 
-    public getRepresentations(periodIndex: number = 0): Representation[] {
-        return this._mpd?.periods?.[periodIndex]?.adaptationSets?.[0]?.representations ?? [];
+    public getRepresentations(periodIndex: number = 0, adaptationSetIndex: number = 0): Representation[] {
+        return this.getAdaptationSets(periodIndex)?.[adaptationSetIndex]?.representations ?? [];
     }
 }


### PR DESCRIPTION
## Purpose

This PR adds a process tick timer in the streamer base. Every streamer processes each tick. In each tick, they perform streaming tasks such as fetch the objects, determine the ray, determine the next segment, fetch segment data, push to buffer etc. 

## Changes

- Add a timer tick to the streamer base. 
- Add a `process()` placeholder which will be implemented next. 
