### PR TITLE
Add RepBase class for common attributes and elements

### DIFF
--- a/src/controller/streamers/streamer.ts
+++ b/src/controller/streamers/streamer.ts
@@ -69,12 +69,12 @@ export default class Streamer {
     }
 
     public onPlay() {
-        log.info(`[${this._name}] onPlay`);
+        log.debug(`[${this._name}] onPlay`);
         this.start();
     }
 
     public onPause() {
-        log.info(`[${this._name}] onPause`);
+        log.debug(`[${this._name}] onPause`);
         this.stop();
     }
 

--- a/src/model/adaptation-set.ts
+++ b/src/model/adaptation-set.ts
@@ -1,4 +1,5 @@
-import ModelBase, { DashTypes } from './base';
+import { DashTypes } from './base';
+import RepBase from './rep-base';
 import SegmentBase from './segment-base';
 import SegmentList from './segment-list';
 import SegmentTemplate from './segment-template';
@@ -32,7 +33,7 @@ export enum StreamType {
  * AdaptationSet element
  * @see ISO/IEC 23009-1:2022, 5.3.3
  */
-export default class AdaptationSet extends ModelBase {
+export default class AdaptationSet extends RepBase {
     public readonly id?: number;
     public readonly group?: number;
     public readonly lang?: string;
@@ -53,8 +54,6 @@ export default class AdaptationSet extends ModelBase {
     public readonly segmentList?: SegmentList;
     public readonly segmentTemplate?: SegmentTemplate;
     public readonly representations?: Representation[];
-    public readonly mimeType?: string; // part of RepresentationBase - move this later
-    public readonly codecs?: string; // part of RepresentationBase - move this later
 
     private readonly _firstRepresentation?: Representation | null;
 

--- a/src/model/rep-base.ts
+++ b/src/model/rep-base.ts
@@ -1,0 +1,52 @@
+import ModelBase, { DashTypes } from './base';
+
+const typeMap = {
+    width: DashTypes.Number,
+    height: DashTypes.Number,
+    frameRate: DashTypes.Number,
+    audioSamplingRate: DashTypes.Number,
+    maximumSAPPeriod: DashTypes.Number,
+    startWithSAP: DashTypes.Number,
+    maxPlayoutRate: DashTypes.Number,
+    codingDependency: DashTypes.Boolean,
+    selectionPriority: DashTypes.Number,
+};
+
+/**
+ * Representation base containing the common attributes and elements
+ * These attrs and elements could be common to AdaptationSet,
+ * Representation and SubRepresentation.
+ * @see ISO/IEC 23009-1:2022, 5.3.7
+ */
+export default class RepBase extends ModelBase {
+    public readonly profiles?: string;
+    public readonly width?: number;
+    public readonly height?: number;
+    public readonly sar?: string;
+    public readonly frameRate?: number; // handle string with prefix
+    public readonly audioSamplingRate?: number; // handle string with commas
+    public readonly mimeType?: string;
+    public readonly segmentProfiles?: string;
+    public readonly codecs?: string;
+    public readonly containerProfiles?: string;
+    public readonly maximumSAPPeriod?: number;
+    public readonly startWithSAP?: number;
+    public readonly maxPlayoutRate?: number;
+    public readonly codingDependency?: boolean;
+    public readonly scanType?: string;
+    public readonly selectionPriority?: number;
+    public readonly tag?: string;
+
+    /**
+     * To add: FramePacking, AudioChannelConfiguration, ContentProtection,
+     * OutputProtection, EssentialProperty, SupplementalProperty , InbandEventStream,
+     * Switching, RandomAccess, GroupLabel, Label, ProducerReferenceTime,
+     * ContentPopularityRate, Resync.
+     */
+
+    constructor(json: Record<string, any>, inputTypeMap: Record<string, DashTypes>) {
+        super(json, { ...inputTypeMap, ...typeMap });
+        this.scanType ??= 'progressive';
+        this.selectionPriority ??= 1;
+    }
+}

--- a/src/model/representation.ts
+++ b/src/model/representation.ts
@@ -1,4 +1,5 @@
-import ModelBase, { DashTypes } from './base';
+import RepBase from './rep-base';
+import { DashTypes } from './base';
 
 const typeMap = {
     qualityRanking: DashTypes.Number,
@@ -9,7 +10,7 @@ const typeMap = {
  * Representation element
  * @see ISO/IEC 23009-1:2022, 5.3.5
  */
-export default class Representation extends ModelBase {
+export default class Representation extends RepBase {
     public readonly id: string;
     public readonly qualityRanking?: number;
     public readonly dependencyId?: string;
@@ -17,8 +18,6 @@ export default class Representation extends ModelBase {
     public readonly associationType?: string;
     public readonly mediaStreamStructureId?: string;
     public readonly bandwidth: number;
-    public readonly mimeType?: string;
-    public readonly codecs?: string;
 
     /**
      * To add: BaseURL, ExtendedBandwidth, SubRepresentation,


### PR DESCRIPTION
## Purpose

The MPD spec has a structure for common attributes and elements which are common to `AdaptationSet`, `Representation` and `SubRepresentation`. In this PR, we define this structure in `RepBase` class and make the other classes that has it as common extend `RepBase`. 

## Changes

- Add `RepBase` class definition. 
- Make `AdaptationSet` and `Representation` extend from `RepBase`
- Remove native player event handlers on cleanup in streaming engine. 

## References

- Common attributes and elements: ISO/IEC 23009-1:2022, 5.3.3
