### PR TITLE
Parse ISO 8601 duration format

### DIFF
--- a/src/model/data-types.ts
+++ b/src/model/data-types.ts
@@ -1,35 +1,97 @@
+const DAYS_PER_WEEK = 7;
+const MILLISECONDS_PER_SECOND = 1000;
+const EPOCH_START = 0;
 
+const DURATION_PATTERN = /^P(.+)$/;
+const TIME_PATTERN     = /T(.+)$/;
+const NUMBER_PATTERN   = /(\d+(?:\.\d+)?)/;
+
+/**
+ * ISO 8601 duration parser
+ * ISO 8601 format: P(n)Y(n)M(n)DT(n)H(n)M(n)S. All components are optional
+ * @see https://en.wikipedia.org/wiki/ISO_8601#Durations
+ */
 export class Duration {
-    public value: number = 0;
-    public timeUnit: 'H' | 'M' | 'S' = 'S';
+    public readonly milliseconds: number;
+    public readonly seconds: number;
+    public readonly durationDate: Date;
 
     constructor(private readonly _rawValue: string) {
-        this.parseDuration();
+        this.durationDate = this._parse();
+        this.milliseconds = this.durationDate.getTime();
+        this.seconds = this.milliseconds / MILLISECONDS_PER_SECOND;
     }
 
-    private parseDuration(): void {
-        // Expected format: PT<number><unit> where unit is H, M, or S
-        const regex = /^PT(\d+(?:\.\d+)?)([HMS])$/;
-        const match = regex.exec(this._rawValue);
-        this.value = parseFloat(match?.[1] ?? '0');
-        this.timeUnit = (match?.[2] as 'H' | 'M' | 'S') ?? 'S';
-    }
-
-    public get seconds(): number {
-        switch (this.timeUnit) {
-            case 'H':
-                return this.value * 3600;
-            case 'M':
-                return this.value * 60;
-            case 'S':
-                return this.value;
-            default:
-                return 0;
+    private _parse(): Date {
+        // First, validate the basic format starts with P
+        const durationMatch = DURATION_PATTERN.exec(this._rawValue);
+        if (!durationMatch) {
+            throw new Error(`Invalid ISO 8601 duration format: ${this._rawValue}`);
         }
+
+        const durationPart = durationMatch[1];
+
+        // Create a base date (epoch start)
+        const durationDate = new Date(EPOCH_START);
+
+        // Parse date components (before T)
+        const timeMatch = TIME_PATTERN.exec(durationPart);
+        const datePart = timeMatch ? durationPart.substring(0, timeMatch.index) : durationPart;
+        const timePart = timeMatch ? timeMatch[1] : '';
+
+        // Parse date components: Y, M, W, D
+        const years  = this._extractComponent(datePart, 'Y');
+        const months = this._extractComponent(datePart, 'M');
+        const weeks  = this._extractComponent(datePart, 'W');
+        const days   = this._extractComponent(datePart, 'D');
+
+        // Parse time components: H, M, S
+        const hours   = this._extractComponent(timePart, 'H');
+        const minutes = this._extractComponent(timePart, 'M');
+        const seconds = this._extractComponent(timePart, 'S');
+
+        // Add years
+        if (years > 0) {
+            durationDate.setFullYear(durationDate.getFullYear() + years);
+        }
+
+        // Add months
+        if (months > 0) {
+            durationDate.setMonth(durationDate.getMonth() + months);
+        }
+
+        // Add weeks (7 days each)
+        if (weeks > 0) {
+            durationDate.setDate(durationDate.getDate() + (weeks * DAYS_PER_WEEK));
+        }
+
+        // Add days
+        if (days > 0) {
+            durationDate.setDate(durationDate.getDate() + days);
+        }
+
+        // Add hours
+        if (hours > 0) {
+            durationDate.setHours(durationDate.getHours() + hours);
+        }
+
+        // Add minutes
+        if (minutes > 0) {
+            durationDate.setMinutes(durationDate.getMinutes() + minutes);
+        }
+
+        // Add seconds
+        if (seconds > 0) {
+            durationDate.setSeconds(durationDate.getSeconds() + seconds);
+        }
+
+        return durationDate;
     }
 
-    public get milliseconds(): number {
-        return this.seconds * 1000;
+    private _extractComponent(part: string, unit: string): number {
+        const pattern = new RegExp(`${NUMBER_PATTERN.source}${unit}`);
+        const match = pattern.exec(part);
+        return match ? parseFloat(match[1]) : 0;
     }
 }
 

--- a/src/model/rep-base.ts
+++ b/src/model/rep-base.ts
@@ -46,7 +46,5 @@ export default class RepBase extends ModelBase {
 
     constructor(json: Record<string, any>, inputTypeMap: Record<string, DashTypes>) {
         super(json, { ...inputTypeMap, ...typeMap });
-        this.scanType ??= 'progressive';
-        this.selectionPriority ??= 1;
     }
 }


### PR DESCRIPTION
## Purpose

In MPD, the duration elements are expressed in ISO 8601 duration format. In this PR, `Duration` class parses the input string and converts to seconds and milliseconds. In some cases, the duration could be huge and bigger than 64-bit double causing overflow. In these cases, the `Date` field elements could be used to get the exact duration. That part is not handled in this PR. 

## Changes

- Add duration string parser in `Duration` class. 

## References

https://en.wikipedia.org/wiki/ISO_8601#Durations
