### PR TITLE
Add SegmentTemplate class

### DIFF
--- a/src/model/base.ts
+++ b/src/model/base.ts
@@ -78,14 +78,14 @@ export default class ModelBase {
         return arrayMember;
     }
 
-    protected _create(classDef: any, elementName: string) {
+    protected _create(classDef: any, elementName: string, property?: string) {
         const className = elementName ?? classDef.name;
 
         if (!this.json?.[className]) {
             return;
         }
 
-        const memberName = toCamelCase(className);
+        const memberName = property ?? toCamelCase(className);
         (this as any)[memberName] = new classDef(this.json[className]);
     }
 

--- a/src/model/multi-segment-base.ts
+++ b/src/model/multi-segment-base.ts
@@ -1,0 +1,27 @@
+import SegmentBase from './segment-base';
+import { DashTypes } from './base';
+
+const typeMap = {
+    duration: DashTypes.Number,
+    startNumber: DashTypes.Number,
+    endNumber: DashTypes.Number,
+};
+
+/**
+ * This is the base class for all multi-segment-based elements,
+ * such as SegmentTemplate, SegmentList etc.
+ * @see ISO/IEC 23009-1:2022, 5.3.9.2
+ */
+export default class MultiSegmentBase extends SegmentBase {
+    public readonly duration?: number;
+    public readonly startNumber?: number;
+    public readonly endNumber?: number;
+
+    /**
+     * To add: SegmentTimeline, BitstreamSwitching
+     */
+
+    constructor(json: Record<string, any>, inputTypeMap: Record<string, DashTypes>) {
+        super(json, { ...inputTypeMap, ...typeMap });
+    }
+}

--- a/src/model/representation.ts
+++ b/src/model/representation.ts
@@ -1,5 +1,6 @@
 import RepBase from './rep-base';
 import { DashTypes } from './base';
+import SegmentTemplate from './segment-template';
 
 const typeMap = {
     qualityRanking: DashTypes.Number,
@@ -18,16 +19,22 @@ export default class Representation extends RepBase {
     public readonly associationType?: string;
     public readonly mediaStreamStructureId?: string;
     public readonly bandwidth: number;
+    public readonly baseUrls?: URL[];
+    public readonly segmentTemplate?: SegmentTemplate;
 
     /**
-     * To add: BaseURL, ExtendedBandwidth, SubRepresentation,
-     * SegmentBase, SegmentList, SegmentTemplate,
+     * To add: ExtendedBandwidth, SubRepresentation,
+     * SegmentBase, SegmentList,
      */
 
     constructor(json: Record<string, any>) {
         super(json, typeMap);
         this.id ??= '';
         this.bandwidth ??= 0;
+
+        this.baseUrls = this._buildArray(URL, 'BaseURL');
+        this._create(SegmentTemplate, 'SegmentTemplate');
+
         this._init();
     }
 }

--- a/src/model/segment-base.ts
+++ b/src/model/segment-base.ts
@@ -9,11 +9,12 @@ const typeMap = {
     indexRangeExact: DashTypes.Boolean,
     availabilityTimeOffset: DashTypes.Number,
     availabilityTimeComplete: DashTypes.Boolean,
-    duration: DashTypes.Number,
 };
 
 /**
  * SegmentBase element
+ * This is the base class for all segment-based elements, such as SegmentTemplate,
+ * SegmentList, SegmentTimeline, etc.
  * @see ISO/IEC 23009-1:2022, 5.3.9.2
  */
 export default class SegmentBase extends ModelBase {
@@ -25,19 +26,18 @@ export default class SegmentBase extends ModelBase {
     public readonly indexRangeExact?: boolean;
     public readonly availabilityTimeOffset?: number;
     public readonly availabilityTimeComplete?: boolean;
-    public readonly duration?: number;
-    public readonly initialization?: URL;
+    public readonly initElement?: URL; // Initialization element
     public readonly representationIndex?: URL;
 
     /**
      * To add: eptDelta, pdDelta, FailoverContent
      */
-    constructor(json: Record<string, any>) {
-        super(json, typeMap);
+    constructor(json: Record<string, any>, inputTypeMap: Record<string, DashTypes>) {
+        super(json, { ...inputTypeMap, ...typeMap });
 
         this.indexRangeExact ??= false;
 
-        this._create(URL, 'Initialization');
+        this._create(URL, 'Initialization', 'initElement');
         this._create(URL, 'RepresentationIndex');
         this._init();
     }

--- a/src/model/segment-template.ts
+++ b/src/model/segment-template.ts
@@ -1,9 +1,17 @@
-import ModelBase from './base';
+import MultiSegmentBase from './multi-segment-base';
 
 /**
  * SegmentTemplate element
  * @see ISO/IEC 23009-1:2022, 5.3.9.4
  */
-export default class SegmentTemplate extends ModelBase {
-    //
+export default class SegmentTemplate extends MultiSegmentBase {
+    public readonly media?: string;
+    public readonly index?: string;
+    public readonly initialization?: string;
+    public readonly bitstreamSwitching?: string;
+
+    constructor(json: Record<string, any>) {
+        super(json, {});
+        this._init();
+    }
 }


### PR DESCRIPTION
## Purpose

This PR adds `SegmentTemplate` class which is an extension of `MultiSegmentBase` class. 

## Changes

- `SegmentTemplate` class definition
- `MultiSegmentBase` class definition
- `SegmentBase` is fixed and made a base class for all segment info classes. 
- `Representation` creates a `SegmentTemplate` if present. 

## References

MPD Spec: ISO/IEC 23009-1:2022, 5.3.9
