### PR TITLE
Resolving segment at various levels in mpd

### DIFF
--- a/src/controller/streamers/streamer-factory.ts
+++ b/src/controller/streamers/streamer-factory.ts
@@ -8,16 +8,20 @@ import AudioStreamer from './audio-streamer';
 import TextStreamer  from './text-streamer';
 import MuxedStreamer from './muxed-streamer';
 
-export function create(streamType: StreamType, media: Media, adaptationSet: AdaptationSet, nativePlayer: NativePlayer): Streamer {
+export function create(streamType: StreamType,
+                       media: Media,
+                       adaptationSet: AdaptationSet,
+                       nativePlayer: NativePlayer,
+                       adaptationSetIndex: number): Streamer {
     switch (streamType) {
         case StreamType.VIDEO:
-            return new VideoStreamer(media, adaptationSet, nativePlayer);
+            return new VideoStreamer(media, adaptationSet, nativePlayer, adaptationSetIndex);
         case StreamType.AUDIO:
-            return new AudioStreamer(media, adaptationSet, nativePlayer);
+            return new AudioStreamer(media, adaptationSet, nativePlayer, adaptationSetIndex);
         case StreamType.TEXT:
-            return new TextStreamer(media, adaptationSet, nativePlayer);
+            return new TextStreamer(media, adaptationSet, nativePlayer, adaptationSetIndex);
         case StreamType.MUXED:
-            return new MuxedStreamer(media, adaptationSet, nativePlayer);
+            return new MuxedStreamer(media, adaptationSet, nativePlayer, adaptationSetIndex);
         default:
             throw new Error(`Unsupported stream type: ${streamType}`);
     }

--- a/src/controller/streaming-engine.ts
+++ b/src/controller/streaming-engine.ts
@@ -38,13 +38,16 @@ export default class StreamingEngine extends EventEmitter {
     }
 
     private _initialize() {
-        for (const adaptationSet of this._media.getAdaptationSets()) {
+        const entries = this._media.getAdaptationSets().entries();
+        for (const [adaptationSetIndex, adaptationSet] of entries) {
             const streamType = adaptationSet.streamType;
             if (streamType === StreamType.UNKNOWN) {
                 continue;
             }
 
-            const streamer = StreamerFactory.create(streamType, this._media, adaptationSet, this._nativePlayer);
+            const streamer = StreamerFactory.create(streamType, this._media,
+                                                    adaptationSet, this._nativePlayer,
+                                                    adaptationSetIndex);
             if (streamer.initialize()) {
                 this._streamers.push(streamer);
             }

--- a/src/model/multi-segment-base.ts
+++ b/src/model/multi-segment-base.ts
@@ -23,5 +23,7 @@ export default class MultiSegmentBase extends SegmentBase {
 
     constructor(json: Record<string, any>, inputTypeMap: Record<string, DashTypes>) {
         super(json, { ...inputTypeMap, ...typeMap });
+        this.startNumber ??= 1; // fix it later
+        this.endNumber ??= this.startNumber; // fix it later
     }
 }

--- a/src/model/representation.ts
+++ b/src/model/representation.ts
@@ -1,6 +1,12 @@
 import RepBase from './rep-base';
 import { DashTypes } from './base';
 import SegmentTemplate from './segment-template';
+import type SegmentBase from './segment-base';
+import type SegmentList from './segment-list';
+import type ISegmentContainer from './segment-container';
+import type { ISegmentResolveInfo } from './segment-container';
+import type Segment from './segment';
+import * as SegmentResolver from './segment-resolver';
 
 const typeMap = {
     qualityRanking: DashTypes.Number,
@@ -11,7 +17,7 @@ const typeMap = {
  * Representation element
  * @see ISO/IEC 23009-1:2022, 5.3.5
  */
-export default class Representation extends RepBase {
+export default class Representation extends RepBase implements ISegmentContainer {
     public readonly id: string;
     public readonly qualityRanking?: number;
     public readonly dependencyId?: string;
@@ -21,6 +27,11 @@ export default class Representation extends RepBase {
     public readonly bandwidth: number;
     public readonly baseUrls?: URL[];
     public readonly segmentTemplate?: SegmentTemplate;
+    public readonly segmentBase?: SegmentBase;
+    public readonly segmentList?: SegmentList;
+
+    public initSegment?: Segment;
+    public basePath?: URL;
 
     /**
      * To add: ExtendedBandwidth, SubRepresentation,
@@ -36,5 +47,9 @@ export default class Representation extends RepBase {
         this._create(SegmentTemplate, 'SegmentTemplate');
 
         this._init();
+    }
+
+    public getSegment(segmentResolveInfo: ISegmentResolveInfo): Segment | null {
+        return SegmentResolver.getSegment(this, segmentResolveInfo);
     }
 }

--- a/src/model/segment-container.ts
+++ b/src/model/segment-container.ts
@@ -1,0 +1,22 @@
+import type SegmentBase from './segment-base';
+import type SegmentList from './segment-list';
+import type SegmentTemplate from './segment-template';
+import type Segment from './segment';
+
+export interface ISegmentResolveInfo {
+    periodIndex: number;
+    adaptationSetIndex: number;
+    representationIndex: number;
+    segmentIndex: number;
+    basePath?: URL;
+}
+
+export default interface ISegmentContainer {
+    basePath?: URL;
+    baseUrls?: URL[];
+    segmentBase?: SegmentBase;
+    segmentList?: SegmentList;
+    segmentTemplate?: SegmentTemplate;
+    initSegment?: Segment;
+    getSegment(segmentResolveInfo: ISegmentResolveInfo): Segment | null;
+}

--- a/src/model/segment-resolver.ts
+++ b/src/model/segment-resolver.ts
@@ -1,0 +1,78 @@
+import Segment from './segment';
+import type ISegmentContainer from './segment-container';
+import type { ISegmentResolveInfo } from './segment-container';
+
+export function getSegment(segmentContainer: ISegmentContainer,
+                           segmentResolveInfo: ISegmentResolveInfo): Segment | null {
+    if (!segmentContainer) {
+        return null;
+    }
+
+    const basePath = getBasePath(segmentContainer, segmentResolveInfo.basePath);
+    const segmentIndex = segmentResolveInfo.segmentIndex;
+
+    if (segmentContainer.segmentTemplate) {
+        return fromTemplate(segmentContainer, basePath, segmentIndex);
+    }
+
+    if (segmentContainer.segmentList) {
+        return fromList();
+    }
+
+    if (segmentContainer.segmentBase) {
+        return fromBase();
+    }
+
+    return null;
+}
+
+function fromTemplate(segmentContainer: ISegmentContainer,
+                      basePath: URL,
+                      segmentIndex: number): Segment | null {
+    const template = segmentContainer.segmentTemplate;
+    if (!template) {
+        return null;
+    }
+
+    const start = template.startNumber ?? 1;
+    const end   = template.endNumber ?? start;
+    if (segmentIndex < start || segmentIndex > end) {
+        return null;
+    }
+
+    const url = resolveUrl(template.media, segmentIndex, basePath);
+    const initSegmentUrl = template.initialization ? new URL(template.initialization, basePath) : new URL('');
+
+    const segment = new Segment({
+        url,
+        initSegmentUrl,
+        seqNum: segmentIndex,
+        duration: template.duration,
+        timescale: template.timescale
+    });
+
+    return segment;
+}
+
+function fromList(): Segment | null {
+    return null; // implement it later
+}
+
+function fromBase(): Segment | null {
+    return null; // implement it later
+}
+
+function getBasePath(segmentContainer: ISegmentContainer, basePath?: URL): URL {
+    if (segmentContainer.baseUrls?.length) {
+        return segmentContainer.baseUrls[0];
+    }
+    return basePath ?? new URL('');
+}
+
+function resolveUrl(url: string | undefined, segmentIndex: number, basePath: URL): URL {
+    if (!url) {
+        return new URL('');
+    }
+    const resolvedUrl = url.replace(/\$Number\$/g, segmentIndex.toString());
+    return new URL(resolvedUrl, basePath);
+}

--- a/src/model/segment.ts
+++ b/src/model/segment.ts
@@ -1,0 +1,38 @@
+export interface ISegmentInfo {
+    url: URL;
+    initSegmentUrl: URL; // Make it an InitSegment type in future
+    duration?: number;
+    start?: number;
+    end?: number;
+    pto?: number;
+    timescale?: number;
+    seqNum?: number;
+    rangeStart?: number;
+    rangeEnd?: number;
+}
+
+export default class Segment {
+    public readonly url: URL;
+    public readonly initSegmentUrl?: URL;
+    public readonly duration: number;
+    public readonly start: number;
+    public readonly end: number;
+    public readonly pto: number;
+    public readonly timescale: number;
+    public readonly seqNum: number;
+    public readonly rangeStart: number;
+    public readonly rangeEnd: number;
+
+    constructor(segInfo: ISegmentInfo) {
+        this.url = segInfo?.url ?? new URL('');
+        this.initSegmentUrl = segInfo?.initSegmentUrl ?? new URL('');
+        this.duration = segInfo?.duration ?? 0;
+        this.start = segInfo?.start ?? NaN;
+        this.end = segInfo?.end ?? NaN;
+        this.pto = segInfo?.pto ?? NaN;
+        this.timescale = segInfo?.timescale ?? 1;
+        this.seqNum = segInfo?.seqNum ?? NaN;
+        this.rangeStart = segInfo?.rangeStart ?? NaN;
+        this.rangeEnd = segInfo?.rangeEnd ?? NaN;
+    }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,3 +5,11 @@ export function toCamelCase(str: string): string {
 export function toTitleCase(str: string): string {
     return str.charAt(0).toUpperCase() + str.slice(1);
 }
+
+// Get the base path of a URL without the filename
+export function getUrlBasePath(url?: URL): string {
+    if (!url) {
+        return '';
+    }
+    return url.href.substring(0, url.href.lastIndexOf('/') + 1);
+}


### PR DESCRIPTION
## Purpose

Section 5.3.9 in MPD spec explains how segment list is expressed in MPD at different levels in the hierarchy. This PR sets up a foundation to retrieve a segment from any level at any given point in time with proper indices as the input. The streamer will retrieve the segment info and load them to fill the buffers. Loading an init or media segment is not part of this. 

## Changes

- Add `segment-resolver.ts` module to implement segment resolution (or retrieval) at any level provided that the instance is an implementation of `ISegmentContainer`. 
- Added `ISegmentContainer`, `ISegmentInfo` and `ISegmentResolveInfo` interface definitions. 
- Added `Segment` class definition. 
- Added `getSegment()` method at various levels in the MPD hierarchy that potentially contains a list of segment. 

## References

MPD spec: ISO/IEC 23009-1:2022(E) 5.3.9