### PR TITLE
Infer segment end number, start and end times

### DIFF
--- a/src/controller/streamers/streamer.ts
+++ b/src/controller/streamers/streamer.ts
@@ -14,7 +14,7 @@ class StreamerState {
     public curPeriodIndex: number = 0;
     public curAdaptationSetIndex: number = 0;
     public curRepIndex: number = 0;
-    public curSegmentIndex: number = 0;
+    public curSegmentNum: number = 0;
 }
 
 const PROCESS_TICK = 20; // in milliseconds
@@ -106,7 +106,7 @@ export default class Streamer {
             return;
         }
 
-        if (this._shouldLoadSegment(segment)) {
+        if (this._shouldLoadSegment()) {
             this._loadSegment(segment);
         }
     }
@@ -123,18 +123,18 @@ export default class Streamer {
         }
 
         return this._media.getSegment({
-            periodIndex: this._state.curPeriodIndex,
+            periodIndex: 1, // this._state.curPeriodIndex,
             adaptationSetIndex: this._state.curAdaptationSetIndex,
             representationIndex: this._state.curRepIndex,
-            segmentIndex: ++this._state.curSegmentIndex
+            segmentNum: ++this._state.curSegmentNum
         });
     }
 
-    protected _shouldLoadSegment(segment: Segment): boolean {
-        return segment.seqNum === this._state.curSegmentIndex;
+    protected _shouldLoadSegment(/* segment: Segment */): boolean {
+        return true; //segment.seqNum === this._state.curSegmentNum;
     }
 
     protected _loadSegment(segment: Segment) {
-        log.debug(`[${this._name}] loadSegment: ${segment.url}`);
+        log.debug(`[${this._name}] loadSegment: [${segment.startTime.toFixed(3)} - ${segment.endTime.toFixed(3)}] ${segment.url}`);
     }
 }

--- a/src/model/adaptation-set.ts
+++ b/src/model/adaptation-set.ts
@@ -8,6 +8,7 @@ import type ISegmentContainer from './segment-container';
 import type { ISegmentResolveInfo } from './segment-container';
 import type Segment from './segment';
 import * as SegmentResolver from './segment-resolver';
+import type { IPeriodInfo } from './data-types';
 
 const typeMap = {
     id: DashTypes.Number,
@@ -63,6 +64,7 @@ export default class AdaptationSet extends RepBase implements ISegmentContainer 
     public basePath?: URL;
 
     private readonly _firstRepresentation?: Representation | null;
+    private _periodInfo?: IPeriodInfo;
 
     /**
      * To add: par, subsegmentStartsWithSAP, initializationSetRef, initializationPrincipal,
@@ -80,6 +82,19 @@ export default class AdaptationSet extends RepBase implements ISegmentContainer 
         this._firstRepresentation = this.representations[0] ?? null;
 
         this._init();
+    }
+
+    public set periodInfo(info: IPeriodInfo) {
+        this._periodInfo = info;
+        this.representations.forEach(representation => {
+            representation.periodInfo = info;
+        });
+        if (this.segmentTemplate) {
+            this.segmentTemplate.periodInfo = info;
+        }
+        if (this.segmentList) {
+            this.segmentList.periodInfo = info;
+        }
     }
 
     public get streamType(): StreamType {

--- a/src/model/data-types.ts
+++ b/src/model/data-types.ts
@@ -99,3 +99,10 @@ export class Descriptor {
     constructor(public value: string) {
     }
 }
+
+export interface IPeriodInfo {
+    startTime: number; // in seconds
+    duration: number; // in seconds
+    endTime: number; // in seconds
+    id?: string;
+}

--- a/src/model/data-types.ts
+++ b/src/model/data-types.ts
@@ -16,8 +16,8 @@ export class Duration {
     public readonly seconds: number;
     public readonly durationDate: Date;
 
-    constructor(private readonly _rawValue: string) {
-        this.durationDate = this._parse();
+    constructor(private readonly _rawValue: string, durationDate?: Date) {
+        this.durationDate = durationDate ?? this._parse();
         this.milliseconds = this.durationDate.getTime();
         this.seconds = this.milliseconds / MILLISECONDS_PER_SECOND;
     }

--- a/src/model/mpd.ts
+++ b/src/model/mpd.ts
@@ -63,5 +63,11 @@ export default class Mpd extends ModelBase {
         this.minBufferTime ??= new Duration('');
 
         this._init();
+
+        /**
+         * Make sure period timing info are all set properly.
+         * If (i) @start attribute is absent, and (ii) the Period element is the first in the MPD, and (iii) the
+         * MPD@type is 'static′, then the PeriodStart time shall be set to zero.
+         */
     }
 }

--- a/src/model/period.ts
+++ b/src/model/period.ts
@@ -1,5 +1,5 @@
 import ModelBase, { DashTypes } from './base';
-import { Descriptor, Duration, type IPeriodInfo } from './data-types';
+import { Descriptor, type Duration, type IPeriodInfo } from './data-types';
 import SegmentBase from './segment-base';
 import SegmentList from './segment-list';
 import SegmentTemplate from './segment-template';
@@ -32,6 +32,7 @@ export default class Period extends ModelBase implements ISegmentContainer {
     public readonly adaptationSets: AdaptationSet[];
 
     public initSegment?: Segment;
+    public endTimeInSeconds?: number;
 
     /**
      * To add: EventStream, ServiceDescription, ContentProtection, Subset,
@@ -54,25 +55,16 @@ export default class Period extends ModelBase implements ISegmentContainer {
         this._init();
     }
 
-    protected _init() {
-        super._init();
-
-        // This should be done in MPD.
-        if (!this.start && this.id === '0') {
-            this.start = new Duration('PT0S');
-        }
-
+    public updateTiming() {
         const startTime = this.start?.seconds ?? 0;
         const duration  = this.duration?.seconds ?? 0;
-        const endTime   = startTime + duration;
-
+        const endTime   = this.endTimeInSeconds ?? startTime + duration;
         const periodInfo: IPeriodInfo = {
             startTime,
             duration,
             endTime,
             id: this.id
         };
-
         this.adaptationSets.forEach(adaptationSet => {
             adaptationSet.periodInfo = periodInfo;
         });

--- a/src/model/representation.ts
+++ b/src/model/representation.ts
@@ -7,6 +7,7 @@ import type ISegmentContainer from './segment-container';
 import type { ISegmentResolveInfo } from './segment-container';
 import type Segment from './segment';
 import * as SegmentResolver from './segment-resolver';
+import type { IPeriodInfo } from './data-types';
 
 const typeMap = {
     qualityRanking: DashTypes.Number,
@@ -33,6 +34,8 @@ export default class Representation extends RepBase implements ISegmentContainer
     public initSegment?: Segment;
     public basePath?: URL;
 
+    private _periodInfo?: IPeriodInfo;
+
     /**
      * To add: ExtendedBandwidth, SubRepresentation,
      * SegmentBase, SegmentList,
@@ -51,5 +54,15 @@ export default class Representation extends RepBase implements ISegmentContainer
 
     public getSegment(segmentResolveInfo: ISegmentResolveInfo): Segment | null {
         return SegmentResolver.getSegment(this, segmentResolveInfo);
+    }
+
+    public set periodInfo(info: IPeriodInfo) {
+        this._periodInfo = info;
+        if (this.segmentTemplate) {
+            this.segmentTemplate.periodInfo = info;
+        }
+        if (this.segmentList) {
+            this.segmentList.periodInfo = info;
+        }
     }
 }

--- a/src/model/representation.ts
+++ b/src/model/representation.ts
@@ -56,6 +56,14 @@ export default class Representation extends RepBase implements ISegmentContainer
         return SegmentResolver.getSegment(this, segmentResolveInfo);
     }
 
+    public get segStartNumber(): number {
+        return this.segmentTemplate?.startNumber ?? this.segmentList?.startNumber ?? 0;
+    }
+
+    public get segEndNumber(): number {
+        return this.segmentTemplate?.endNumber ?? this.segmentList?.endNumber ?? 0;
+    }
+
     public set periodInfo(info: IPeriodInfo) {
         this._periodInfo = info;
         if (this.segmentTemplate) {

--- a/src/model/segment-base.ts
+++ b/src/model/segment-base.ts
@@ -36,6 +36,7 @@ export default class SegmentBase extends ModelBase {
         super(json, { ...inputTypeMap, ...typeMap });
 
         this.indexRangeExact ??= false;
+        this.timescale ??= 1;
 
         this._create(URL, 'Initialization', 'initElement');
         this._create(URL, 'RepresentationIndex');

--- a/src/model/segment-container.ts
+++ b/src/model/segment-container.ts
@@ -7,7 +7,7 @@ export interface ISegmentResolveInfo {
     periodIndex: number;
     adaptationSetIndex: number;
     representationIndex: number;
-    segmentIndex: number;
+    segmentNum: number;
     basePath?: URL;
 }
 

--- a/src/model/segment-list.ts
+++ b/src/model/segment-list.ts
@@ -1,9 +1,9 @@
-import ModelBase from './base';
+import MultiSegmentBase from './multi-segment-base';
 
 /**
  * SegmentList element
  * @see ISO/IEC 23009-1:2022, 5.3.9.3
  */
-export default class SegmentList extends ModelBase {
+export default class SegmentList extends MultiSegmentBase {
     //
 }

--- a/src/model/segment-resolver.ts
+++ b/src/model/segment-resolver.ts
@@ -39,23 +39,25 @@ function fromTemplate(segmentContainer: ISegmentContainer,
     // Find the position within the segment list:
     const start = template.startNumber ?? 1;
     const end   = template.endNumber ?? start;
-    const pos   = segmentNum - 1 + start;
+    const pos   = segmentNum;
     if (pos < start || pos > end) {
         return null;
     }
 
     // Find start and end times:
     // If duration is absent, then we must use SegmentTimeline. (fix it later)
+    const periodStart = periodInfo?.startTime ?? 0;
+    const periodEnd   = periodInfo?.endTime ?? 0;
     let duration  = template.durationSecs ?? 0;
-    const startTime = (pos - start) * duration;
+    const startTime = periodStart + (pos - start) * duration;
     let endTime   = startTime + duration;
 
     if (periodInfo) {
-        if (startTime < periodInfo.startTime || startTime > periodInfo.endTime) {
+        if (startTime < periodStart || startTime > periodEnd) {
             return null;
         }
-        if (endTime > periodInfo.endTime) {
-            endTime = periodInfo.endTime;
+        if (endTime > periodEnd) {
+            endTime = periodEnd;
             duration = endTime - startTime;
         }
     }

--- a/src/model/segment.ts
+++ b/src/model/segment.ts
@@ -1,9 +1,9 @@
 export interface ISegmentInfo {
     url: URL;
     initSegmentUrl: URL; // Make it an InitSegment type in future
-    duration?: number;
-    start?: number;
-    end?: number;
+    duration?: number; // in seconds
+    startTime?: number;
+    endTime?: number;
     pto?: number;
     timescale?: number;
     seqNum?: number;
@@ -14,9 +14,9 @@ export interface ISegmentInfo {
 export default class Segment {
     public readonly url: URL;
     public readonly initSegmentUrl?: URL;
-    public readonly duration: number;
-    public readonly start: number;
-    public readonly end: number;
+    public readonly duration: number; // in seconds
+    public readonly startTime: number; // in seconds
+    public readonly endTime: number; // in seconds
     public readonly pto: number;
     public readonly timescale: number;
     public readonly seqNum: number;
@@ -27,8 +27,8 @@ export default class Segment {
         this.url = segInfo?.url ?? new URL('');
         this.initSegmentUrl = segInfo?.initSegmentUrl ?? new URL('');
         this.duration = segInfo?.duration ?? 0;
-        this.start = segInfo?.start ?? NaN;
-        this.end = segInfo?.end ?? NaN;
+        this.startTime = segInfo?.startTime ?? NaN;
+        this.endTime = segInfo?.endTime ?? NaN;
         this.pto = segInfo?.pto ?? NaN;
         this.timescale = segInfo?.timescale ?? 1;
         this.seqNum = segInfo?.seqNum ?? NaN;


### PR DESCRIPTION
## Purpose

When `endNumber` is not present in a `SegmentTemplate`, we have to infer it from the period duration and segment duration. In this PR, we compute and update period start and end timings for all the periods. Then we compute the start and end timings of the requested segment. We infer the end number (last segment sequence number) from the timing info. 

## Changes

- Compute period start and end timings in MPD and update it in all period instances. 
- Period will propagate the period info to all children elements that are segment containers. 
- Period info will be used during segment resolve to compute/infer the segment start, end times and also the segment number. 

## References

ISO/IEC 23009-1:2022(E) Sections 5.3.2.1 and 5.3.9.5
