### PR TITLE
Implement src buffer queuing

### DIFF
--- a/src/controller/streamers/streamer.ts
+++ b/src/controller/streamers/streamer.ts
@@ -22,6 +22,7 @@ class StreamerState {
 }
 
 const PROCESS_TICK = 20; // in milliseconds
+const SEGMENT_LOAD_LIMIT = 100;
 
 /**
  * Streamer is a class that handles the streaming of a media stream.
@@ -163,7 +164,7 @@ export default class Streamer {
         if (this._state.segmentLoading) {
             return false;
         }
-        return segment.seqNum <= 2;
+        return segment.seqNum <= SEGMENT_LOAD_LIMIT;
     }
 
     protected async _loadSegment(segment: Segment) {


### PR DESCRIPTION
## Purpose

This PR implements the queuing of chunks received at the buffer sink. They need to be queued because the source buffer append is an async operation and no further chunks can be appended when it is updating. We queue the chunks and listen to update finish events. Then we move further chunks to the src buffer iteratively. 

## Changes

- Add a queue in `Buffer` class to queue the chunks. 
- Listen to src buffer events and move the chunks to src buffer when it is free. 
- Handle error.
- Test by loading 100 segments of a sample video. We haven't detected the end of video or the last segment yet. 

## References

https://developer.mozilla.org/en-US/docs/Web/API/SourceBuffer
