### PR TITLE
Better streamer flow

### DIFF
--- a/demo/playerdemo.js
+++ b/demo/playerdemo.js
@@ -3,6 +3,10 @@ class PlayerDemo {
     constructor() {
         this.playerContainer = document.getElementById('player-container');
         this.player = new window.DHARA.Player(this.playerContainer);
+
+        // For easier debugging & testing.
+        window.dp  = this.player;
+        window.dpe = this.player.element();
     }
 
     selectSample(id) {

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -13,6 +13,8 @@ enum DPlayerState {
     FETCHING_SRC = 'FetchingSrc',
     PREPARING = 'Preparing',
     READY = 'Ready',
+    STREAMING = 'Streaming',
+    END_OF_STREAM = 'EndOfStream',
     ERROR = 'Error',
 }
 
@@ -42,6 +44,10 @@ export default class DharaPlayerController extends EventEmitter {
         this._media.destroy();
         this._streamingEngine?.destroy();
         this._streamingEngine = null;
+    }
+
+    public element(): HTMLMediaElement | null {
+        return this._nativePlayer?.mediaElement ?? null;
     }
 
     private async setState(state: DPlayerState, data?: any) {
@@ -92,7 +98,26 @@ export default class DharaPlayerController extends EventEmitter {
         }
 
         this._streamingEngine = new StreamingEngine(this._media, this._nativePlayer);
-        this._streamingEngine.on(StreamingEngineEvent.ERROR, (errMsg: string) => { this.error = errMsg; });
+
+        this._streamingEngine.on(StreamingEngineEvent.ERROR, (errMsg: string) => {
+            this.error = errMsg;
+        });
+
+        this._streamingEngine.on(StreamingEngineEvent.STREAMING, () => {
+            this.setState(DPlayerState.STREAMING);
+        });
+
+        this._streamingEngine.on(StreamingEngineEvent.END_OF_STREAM, () => {
+            this.setState(DPlayerState.END_OF_STREAM);
+        });
+    }
+
+    private _onStreaming() {
+        //
+    }
+
+    private _onEndOfStream() {
+        //
     }
 
     private async _onError(data?: any) {

--- a/src/controller/streaming-engine.ts
+++ b/src/controller/streaming-engine.ts
@@ -9,6 +9,8 @@ import { toTitleCase } from '../utils';
 
 export enum StreamingEngineEvent {
     ERROR = 'error',
+    STREAMING = 'streaming',
+    END_OF_STREAM = 'endOfStream',
 }
 
 export default class StreamingEngine extends EventEmitter {
@@ -88,14 +90,18 @@ export default class StreamingEngine extends EventEmitter {
         }
     }
 
-    private _onTimeupdate() {
-        for (const streamer of this._streamers) {
-            streamer.onTimeupdate();
-        }
+    private _onPlay(...args: any[]) {
+        this._sendEventToStreamers('onPlay', ...args);
+        this.emit(StreamingEngineEvent.STREAMING);
+    }
+
+    private _onTimeupdate(...args: any[]) {
+        this._sendEventToStreamers('onTimeupdate', ...args);
 
         const mediaSource = this._nativePlayer.mediaSource;
         if (this._areAllBuffersClosed() && mediaSource?.readyState === MediaSourceReadyState.OPEN) {
             mediaSource.endOfStream();
+            this.emit(StreamingEngineEvent.END_OF_STREAM);
         }
     }
 

--- a/src/dhara-player.ts
+++ b/src/dhara-player.ts
@@ -11,6 +11,10 @@ export default class DharaPlayer {
         this._controller.setSource(sourceUrl);
     }
 
+    public element(): HTMLMediaElement | null {
+        return this._controller.element();
+    }
+
     public destroy() {
         this._controller.destroy();
     }


### PR DESCRIPTION
## Purpose

In this PR we use `StreamerState` class to better or simplify the flow in `Streamer`. 

## Changes

- Improve `StreamerState` implementation
- Simplify the flow in `Streamer`
- Make player and video element easily accessible on the demo page. (for testing & debugging)
- Complete the state machine in Controller with `Streaming`, `EndOfStream` states. 

## Note

- Replay will not work after `EndOfStream` state. Some work required to make it happen without losing the previous buffer or reloading media. 
