### PR TITLE
Fix: Safari playback issue

### DIFF
--- a/src/controller/streamers/streamer-state.ts
+++ b/src/controller/streamers/streamer-state.ts
@@ -1,9 +1,9 @@
-import AdaptationSet from "../../model/adaptation-set";
-import Media from "../../model/media";
-import Period from "../../model/period";
-import Representation from "../../model/representation";
-import Segment from "../../model/segment";
-import { ISegmentResolveInfo } from "../../model/segment-container";
+import type AdaptationSet from "../../model/adaptation-set";
+import type Media from "../../model/media";
+import type Period from "../../model/period";
+import type Representation from "../../model/representation";
+import type Segment from "../../model/segment";
+import type { ISegmentResolveInfo } from "../../model/segment-container";
 
 export default class StreamerState {
     private readonly _curAdaptationSet: AdaptationSet;

--- a/src/controller/streamers/streamer.ts
+++ b/src/controller/streamers/streamer.ts
@@ -136,9 +136,7 @@ export default class Streamer {
             return;
         }
 
-        if (this._isSegmentAvailable(segmentNum)) {
-            this._loadSegment(this._getSegment(segmentNum));
-        }
+        this._loadSegment(this._getSegment(segmentNum));
     }
 
     protected _determineRepresentation(): Representation | null {
@@ -153,9 +151,6 @@ export default class Streamer {
         }
 
         return this._state.shouldLoadSegment();
-
-        // const range = this._adaptationSet.getSegRange();
-        // return segmentNum >= range[0] && segmentNum <= range[1];
     }
 
     protected _getNextSegmentNum(targetPosition: number): number {
@@ -171,10 +166,6 @@ export default class Streamer {
         // If discontinuous, then probably we are at the beginning.
         // Otherwise, just move forward.
         return state.continuous ? state.nextSegmentNum : state.firstSegmentNum;
-    }
-
-    protected _isSegmentAvailable(segmentNum: number): boolean {
-        return true; // always true in VOD
     }
 
     protected _getSegment(segmentNum: number): Segment | null {


### PR DESCRIPTION
## Purpose

Safari does not implement `readableStream` as a async iterable. As a result, the Safari throws an exception during init segment loaded data reading. In this PR, I fix it by implementing the reading by using a reader instead of `for await ...` async iteration. It is less elegant but it works in Safari. 

