### PR TITLE
Feat: Cleanup past buffers

### DIFF
--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -97,6 +97,12 @@ export default class DharaPlayerController extends EventEmitter {
             return;
         }
 
+        const srcBufferCount = this._nativePlayer.mediaSource?.activeSourceBuffers.length ?? 0;
+        if (this._streamingEngine && srcBufferCount) {
+            this.setState(DPlayerState.STREAMING);
+            return;
+        }
+
         this._streamingEngine = new StreamingEngine(this._media, this._nativePlayer);
 
         this._streamingEngine.on(StreamingEngineEvent.ERROR, (errMsg: string) => {

--- a/src/controller/streamers/streamer-state.ts
+++ b/src/controller/streamers/streamer-state.ts
@@ -21,6 +21,7 @@ export default class StreamerState {
     private _curSegmentNum: number = NaN;
 
     private _segmentLoading: boolean = false;
+    private _initSegmentLoaded: boolean = false;
     private _endOfStream: boolean = false;
     private _seeking: boolean = false;
 
@@ -59,6 +60,16 @@ export default class StreamerState {
 
     public onSegmentLoadAborted() {
         this._segmentLoading = false;
+        this._endOfStream = false;
+        this._initSegmentLoaded = false;
+    }
+
+    public set initSegmentLoaded(value: boolean) {
+        this._initSegmentLoaded = value;
+    }
+
+    public get initSegmentLoaded(): boolean {
+        return this._initSegmentLoaded;
     }
 
     public isFirstSegment(): boolean {


### PR DESCRIPTION
## Purpose

Seeking at random places back and forth will start fragment the buffered ranges. In a long form content, there could be a lot of buffered ranges. Although browsers have their own buffer cleanup mechanism, the behavior varies across browsers. Therefore, it is a good idea to cleanup the past buffers (far enough from the current time). Currently it is set to 30 sec. In future, we will make it a configurable. 

## Changes

- Calculate the past buffer length in each source buffer and clean them up if they are above the threshold. 
- Minor changes to the seek flow to fix abort issues. 
- Seek after stream end should re open the buffer (i.e, endOfstream should be false)
- Fixed buffer length calculation in the streamer

## Todos

- Sometimes, Firefox browser throws `Insufficient data` exception. This needs a fix. 
- Need to clear the future buffer which is far enough
- Need to handle Quota Exceeds error. 
